### PR TITLE
Do not use compiled template outside of production

### DIFF
--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -67,8 +67,6 @@ module ActionView
       # We could in theory do this on app boot, at least in production environments.
       # Right now this just compiles the template the first time the component is rendered.
       def compile
-        # Only use compiled method if we're in production. Eventually, we'll probably want to
-        # use something like Rails.application.config for this toggle instead.
         return if @compiled && ActionView::Base.cache_template_loading
 
         class_eval("def call; @output_buffer = ActionView::OutputBuffer.new; #{compiled_template}; end")

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -100,7 +100,7 @@ module ActionView
 
         if sibling_files.length == 0
           raise NotImplementedError.new(
-            "Could not find a template for #{self}. Either define a .template method or add a sidecar template file."
+            "Could not find a template file for #{self}."
           )
         end
 

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -67,7 +67,7 @@ module ActionView
       # We could in theory do this on app boot, at least in production environments.
       # Right now this just compiles the template the first time the component is rendered.
       def compile
-        return if @compiled
+        return if @compiled && Rails.env.production?
 
         class_eval("def call; @output_buffer = ActionView::OutputBuffer.new; #{compiled_template}; end")
 

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -67,6 +67,8 @@ module ActionView
       # We could in theory do this on app boot, at least in production environments.
       # Right now this just compiles the template the first time the component is rendered.
       def compile
+        # Only use compiled method if we're in production. Eventually, we'll probably want to
+        # use something like Rails.application.config for this toggle instead.
         return if @compiled && Rails.env.production?
 
         class_eval("def call; @output_buffer = ActionView::OutputBuffer.new; #{compiled_template}; end")

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -69,7 +69,7 @@ module ActionView
       def compile
         # Only use compiled method if we're in production. Eventually, we'll probably want to
         # use something like Rails.application.config for this toggle instead.
-        return if @compiled && Rails.env.production?
+        return if @compiled && ActionView::Base.cache_template_loading
 
         class_eval("def call; @output_buffer = ActionView::OutputBuffer.new; #{compiled_template}; end")
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -16,7 +16,7 @@ class ActionView::ComponentTest < Minitest::Test
       render_component(TestComponentWithoutTemplate.new)
     end
 
-    assert_includes exception.message, "Could not find a template for TestComponentWithoutTemplate"
+    assert_includes exception.message, "Could not find a template file for TestComponentWithoutTemplate"
   end
 
   def test_raises_error_when_more_then_one_sidecar_template_is_present

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -79,7 +79,7 @@ class ActionView::ComponentTest < Minitest::Test
   end
 
   def test_template_changes_are_not_reflected_in_production
-    Rails.stub(:env, ActiveSupport::StringInquirer.new('production')) do
+    Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
       assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
 
       modify_file "app/components/test_component.html.erb", "<div>Goodbye world!</div>" do

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -79,18 +79,20 @@ class ActionView::ComponentTest < Minitest::Test
   end
 
   def test_template_changes_are_not_reflected_in_production
-    Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
-      assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
+    ActionView::Base.cache_template_loading = true
 
-      modify_file "app/components/test_component.html.erb", "<div>Goodbye world!</div>" do
-        assert_equal  "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
-      end
+    assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
 
-      assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
+    modify_file "app/components/test_component.html.erb", "<div>Goodbye world!</div>" do
+      assert_equal  "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
     end
+
+    assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
   end
 
   def test_template_changes_are_reflected_outside_production
+    ActionView::Base.cache_template_loading = false
+
     assert_equal "<div>hello,world!</div>", render_component(TestComponent.new).css("div").first.to_html
 
     modify_file "app/components/test_component.html.erb", "<div>Goodbye world!</div>" do


### PR DESCRIPTION
This PR addresses https://github.com/github/actionview-component/issues/19 where template changes were not reflected when reloading a page in development.

It also corrects an error message that referenced the now-removed inline template functionality.

The `modify_file` test helper is shamelessly adapted from `rails/actionview/test/template/compiled_templates_test.rb`.

cc @metade @mikker