### PR TITLE
Allow component template inheritance.

### DIFF
--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -33,14 +33,6 @@ class ActionView::ComponentTest < Minitest::Test
     assert_includes error.message, "More than one template found for TooManySidecarFilesComponent."
   end
 
-  def test_raises_error_when_initializer_is_not_defined
-    exception = assert_raises NotImplementedError do
-      render_inline(MissingInitializerComponent)
-    end
-
-    assert_includes exception.message, "must implement #initialize"
-  end
-
   def test_checks_validations
     exception = assert_raises ActiveModel::ValidationError do
       render_inline(WrapperComponent)
@@ -96,6 +88,16 @@ class ActionView::ComponentTest < Minitest::Test
     result = render_inline(RouteComponent)
 
     assert_includes result.text, "/"
+  end
+
+  def test_extending_component_without_own_template
+    result = render_inline(ExtendingWithoutOwnTemplateComponent, message: "foo").css("div").first.to_html
+    assert_equal result, "<div>base: extended foo</div>"
+  end
+
+  def test_extending_component_with_own_template
+    result = render_inline(ExtendingWithOwnTemplateComponent, message: "bar").css("div").first.to_html
+    assert_equal result, "<div>extending: extended bar</div>"
   end
 
   def test_template_changes_are_not_reflected_in_production

--- a/test/app/components/base_component.html.erb
+++ b/test/app/components/base_component.html.erb
@@ -1,0 +1,1 @@
+<div>base: <%= @message %></div>

--- a/test/app/components/base_component.rb
+++ b/test/app/components/base_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BaseComponent < ActionView::Component::Base
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/test/app/components/extending_with_own_template_component.html.erb
+++ b/test/app/components/extending_with_own_template_component.html.erb
@@ -1,0 +1,1 @@
+<div>extending: <%= @message %></div>

--- a/test/app/components/extending_with_own_template_component.rb
+++ b/test/app/components/extending_with_own_template_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ExtendingWithOwnTemplateComponent < BaseComponent
+  def initialize(message:)
+    super(message: "extended #{message}")
+  end
+end

--- a/test/app/components/extending_without_own_template_component.rb
+++ b/test/app/components/extending_without_own_template_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ExtendingWithoutOwnTemplateComponent < BaseComponent
+  def initialize(message:)
+    super(message: "extended #{message}")
+  end
+end

--- a/test/app/components/missing_initializer_component.rb
+++ b/test/app/components/missing_initializer_component.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class MissingInitializerComponent < ActionView::Component::Base
-end


### PR DESCRIPTION
Hi,

this PR changes the way the `template_file_path` is resolved. The idea is to walk up the ancestors chain until an ancestor with a template is found. This enables template inheritance:

```ruby
# link_component.rb
class LinkComponent < ActionView::Component::Base
  def initialize(url:, name:, **options)
    @url = url 
    @name = name 
    @options = options
  end

  private 

  attr_reader :url, :text, :options
end
```
```erb
# link_component.html.erb
<%= link_to name, url, options %>
```
```ruby
# funk_link_component.rb
class FunkyLinkComponent < LinkComponent
  def initialize(name:, url:, **options)
    super(name: name, url: url, options: options.merge(class: 'funky'))
  end
end
```
```ruby
render(LinkComponent, name: "Unfunky", url: unfunky_path)
# => <a href="/unfunky">Unfunky</a>

render(FunkyLinkComponent, name: "Funky", url: funky_path)
# => <a href="/funky" class="funky">Funky</a>
```