### PR TITLE
Fix implicit partial rendering from components

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -74,7 +74,7 @@ module ActionView
       def initialize(*); end
 
       def render(options = {}, args = {}, &block)
-        if options.is_a?(Hash) && options.has_key?(:partial)
+        if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
           view_context.render(options, args, &block)
         else
           super

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -26,7 +26,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   test "rendering component with a partial" do
     get "/partial"
     assert_response :success
-    assert_equal trim_result(response.body), "partial:<div>hello,partialworld!</div>component:<div>hello,partialworld!</div>"
+    assert_equal trim_result(response.body), "partial:<div>hello,partialworld!</div>component:<div>hello,partialworld!</div><div>hello,partialworld!</div>"
   end
 
   test "rendering component in a view with deprecated syntax" do

--- a/test/app/components/partial_component.html.erb
+++ b/test/app/components/partial_component.html.erb
@@ -1,1 +1,2 @@
 <%= render partial: "test_partial" %>
+<%= render "test_partial" %>


### PR DESCRIPTION
It's possible to render a partial by calling render with the partial string, i.e. without using the partial keyword argument.

Updating ActionView::Component::Base#render to handle this.