### PR TITLE
Allow sidecar CSS files

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -117,7 +117,7 @@ module ActionView
 
           filename = self.instance_method(:initialize).source_location[0]
           filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
-          sibling_template_files = Dir["#{filename_without_extension}.????.{#{ActionView::Template.template_handler_extensions.join(",")}}"] - [filename]
+          sibling_template_files = Dir["#{filename_without_extension}.????.{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [filename]
 
           if sibling_template_files.length > 1
             raise StandardError.new("More than one template found for #{self}. There can only be one sidecar template file per component.")

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -117,7 +117,7 @@ module ActionView
 
           filename = self.instance_method(:initialize).source_location[0]
           filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
-          sibling_template_files = Dir["#{filename_without_extension}.html.{#{ActionView::Template.template_handler_extensions.join(",")}}"] - [filename]
+          sibling_template_files = Dir["#{filename_without_extension}.????.{#{ActionView::Template.template_handler_extensions.join(",")}}"] - [filename]
 
           if sibling_template_files.length > 1
             raise StandardError.new("More than one template found for #{self}. There can only be one sidecar template file per component.")

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -117,19 +117,19 @@ module ActionView
 
           filename = self.instance_method(:initialize).source_location[0]
           filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
-          sibling_files = Dir["#{filename_without_extension}.*"] - [filename]
+          sibling_template_files = Dir["#{filename_without_extension}.html.{#{ActionView::Template.template_handler_extensions.join(",")}}"] - [filename]
 
-          if sibling_files.length > 1
+          if sibling_template_files.length > 1
             raise StandardError.new("More than one template found for #{self}. There can only be one sidecar template file per component.")
           end
 
-          if sibling_files.length == 0
+          if sibling_template_files.length == 0
             raise NotImplementedError.new(
               "Could not find a template file for #{self}."
             )
           end
 
-          sibling_files[0]
+          sibling_template_files[0]
         end
       end
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -130,6 +130,12 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
+  def test_renders_component_with_css_sidecar
+    result = render_inline(CssSidecarFileComponent)
+
+    assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
+  end
+
   def test_template_changes_are_not_reflected_in_production
     ActionView::Base.cache_template_loading = true
 

--- a/test/app/components/css_sidecar_file_component.css
+++ b/test/app/components/css_sidecar_file_component.css
@@ -1,0 +1,3 @@
+div {
+  font-weight: bold;
+}

--- a/test/app/components/css_sidecar_file_component.html.erb
+++ b/test/app/components/css_sidecar_file_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello, world!</div>

--- a/test/app/components/css_sidecar_file_component.rb
+++ b/test/app/components/css_sidecar_file_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CssSidecarFileComponent < ActionView::Component::Base
+  def initialize(*)
+  end
+end


### PR DESCRIPTION
This PR tightens our template file lookup logic so that non-template files do not trigger the multiple-sidecar-files error.

[Fixes #55]