### PR TITLE
allow access to request in component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Allow access to `request` inside components.
+
+    *Joel Hawksley*
+
 # v1.3.3
 
 *   Do not raise error when sidecar files that are not templates exist.

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -61,6 +61,7 @@ module ActionView
       def render_in(view_context, *args, &block)
         self.class.compile
         self.controller = view_context.controller
+        self.request = controller.request
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer
         @lookup_context ||= view_context.lookup_context

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -60,8 +60,6 @@ module ActionView
       #
       def render_in(view_context, *args, &block)
         self.class.compile
-        self.controller = view_context.controller
-        self.request = controller.request
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer
         @lookup_context ||= view_context.lookup_context
@@ -152,6 +150,14 @@ module ActionView
       end
 
       private
+
+      def controller
+        @controller ||= view_context.controller
+      end
+
+      def request
+        @request ||= controller.request
+      end
 
       attr_reader :content, :view_context
     end

--- a/lib/action_view/component/test_helpers.rb
+++ b/lib/action_view/component/test_helpers.rb
@@ -8,7 +8,11 @@ module ActionView
       end
 
       def controller
-        @controller ||= ApplicationController.new.tap { |c| c.request = ActionDispatch::TestRequest.create }
+        @controller ||= ApplicationController.new.tap { |c| c.request = request }
+      end
+
+      def request
+        @request ||= ActionDispatch::TestRequest.create
       end
 
       def render_component(component, **args, &block)

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -136,6 +136,12 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
+  def test_renders_component_with_request_context
+    result = render_inline(RequestComponent)
+
+    assert_equal trim_result(result.css("div").first.to_html), "<div>0.0.0.0</div>"
+  end
+
   def test_template_changes_are_not_reflected_in_production
     ActionView::Base.cache_template_loading = true
 

--- a/test/app/components/request_component.html.erb
+++ b/test/app/components/request_component.html.erb
@@ -1,0 +1,1 @@
+<div><%= request.ip %></div>

--- a/test/app/components/request_component.rb
+++ b/test/app/components/request_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RequestComponent < ActionView::Component::Base
+  def initialize(*); end
+end


### PR DESCRIPTION
In order for certain helpers (such as those from `devise`) to work, we need to have access to the `request`. 

cc @cjbottaro