### PR TITLE
Add ActionView::Component::VERSION constants

### DIFF
--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -3,10 +3,11 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "action_view/component/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "actionview-component"
-  spec.version       = "1.3.4"
+  spec.version       = ActionView::Component::VERSION::STRING
   spec.authors       = ["GitHub Open Source"]
   spec.email         = ["opensource+actionview-component@github.com"]
 

--- a/lib/action_view/component/version.rb
+++ b/lib/action_view/component/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Component
+    module VERSION
+      MAJOR = 1
+      MINOR = 3
+      PATCH = 4
+
+      STRING = [MAJOR, MINOR, PATCH].join(".")
+    end
+  end
+end

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -166,6 +166,22 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
   end
 
+  def test_that_it_has_a_version_number
+    refute_nil ::ActionView::Component::VERSION::MAJOR
+    assert_kind_of Integer, ::ActionView::Component::VERSION::MAJOR
+    refute_nil ::ActionView::Component::VERSION::MINOR
+    assert_kind_of Integer, ::ActionView::Component::VERSION::MINOR
+    refute_nil ::ActionView::Component::VERSION::PATCH
+    assert_kind_of Integer, ::ActionView::Component::VERSION::PATCH
+
+    version_string = [
+      ::ActionView::Component::VERSION::MAJOR,
+      ::ActionView::Component::VERSION::MINOR,
+      ::ActionView::Component::VERSION::PATCH
+    ].join(".")
+    assert_equal version_string, ::ActionView::Component::VERSION::STRING
+  end
+
   private
 
   def modify_file(file, content)


### PR DESCRIPTION
Adding these constants enables consumers to programmatically access the version with ease, e.g.

```rb
unless ActionView::Component::VERSION::STRING == '1.3.4'
  raise 'Remove this patch when upgrading ActionView::Component'
end

# some monkey patch that's only needed in version 1.3.4 ...
```
or
```rb
if ActionView::Component::VERSION::MAJOR == 1
  # some logic using the v1 API ...
else
  # some logic using the newer API ...
end
```