### PR TITLE
Components should also check view directory for template files

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -125,7 +125,8 @@ module ActionView
 
           filename = self.instance_method(:initialize).source_location[0]
           filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
-          sibling_template_files = Dir["#{filename_without_extension}.????.{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [filename]
+          sibling_template_files = file_path_array(filename_without_extension) - [filename]
+          sibling_template_files = file_path_array(Rails.root.join("app", "views", "components", File.basename(filename, ".*")).to_s) if sibling_template_files.blank?
 
           if sibling_template_files.length > 1
             raise StandardError.new("More than one template found for #{self}. There can only be one sidecar template file per component.")
@@ -139,6 +140,11 @@ module ActionView
 
           sibling_template_files[0]
         end
+
+        def file_path_array(filename)
+          Dir["#{filename}.????.{#{ActionView::Template.template_handler_extensions.join(',')}}"]
+        end
+        
       end
 
       class DummyTemplate

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -144,7 +144,6 @@ module ActionView
         def file_path_array(filename)
           Dir["#{filename}.????.{#{ActionView::Template.template_handler_extensions.join(',')}}"]
         end
-        
       end
 
       class DummyTemplate

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -172,7 +172,6 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
   end
 
-<<<<<<< HEAD
   def test_that_it_has_a_version_number
     refute_nil ::ActionView::Component::VERSION::MAJOR
     assert_kind_of Integer, ::ActionView::Component::VERSION::MAJOR
@@ -189,8 +188,6 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal version_string, ::ActionView::Component::VERSION::STRING
   end
 
-=======
->>>>>>> Remove whitespace
   def test_renders_component_with_template_in_view_directory
     result = render_inline(ViewBasedComponent)
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -172,6 +172,7 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
   end
 
+<<<<<<< HEAD
   def test_that_it_has_a_version_number
     refute_nil ::ActionView::Component::VERSION::MAJOR
     assert_kind_of Integer, ::ActionView::Component::VERSION::MAJOR
@@ -188,6 +189,8 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal version_string, ::ActionView::Component::VERSION::STRING
   end
 
+=======
+>>>>>>> Remove whitespace
   def test_renders_component_with_template_in_view_directory
     result = render_inline(ViewBasedComponent)
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -188,6 +188,12 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal version_string, ::ActionView::Component::VERSION::STRING
   end
 
+  def test_renders_component_with_template_in_view_directory
+    result = render_inline(ViewBasedComponent)
+
+    assert_equal trim_result(result.css("div").first.to_html), "<div>hello,viewbasedcomponent!</div>"
+  end
+
   private
 
   def modify_file(file, content)

--- a/test/app/components/view_based_component.rb
+++ b/test/app/components/view_based_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ViewBasedComponent < ActionView::Component::Base
+  def initialize(*)
+  end
+end

--- a/test/app/views/components/view_based_component.html.erb
+++ b/test/app/views/components/view_based_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello, view based component!</div>


### PR DESCRIPTION
Whilst working with `ActionView::Components` on one of our projects I noticed that the main components directory was becoming cumbersome with all the different file types in the same directory. So I added a one-liner to allow loading the template files from the `app/views/components` directory. My team really liked having a set structure for our components and not going against already defined rails conventions. So we ended up with the following structure.

```
# assets/stylesheets/components/button.scss
# app/components/button.rb
# app/view/components/button.html.erb
```
