### PR TITLE
Preselect the rendered component in render_inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ class MyComponentTest < Minitest::Test
   def test_render_component
     assert_equal(
       %(<span title="my title">Hello, World!</span>),
-      render_inline(TestComponent, title: "my title") { "Hello, World!" }.css("span").to_html
+      render_inline(TestComponent, title: "my title") { "Hello, World!" }.to_html
     )
   end
 end

--- a/lib/action_view/component/test_helpers.rb
+++ b/lib/action_view/component/test_helpers.rb
@@ -4,7 +4,7 @@ module ActionView
   module Component
     module TestHelpers
       def render_inline(component, **args, &block)
-        Nokogiri::HTML(controller.view_context.render(component, args, &block))
+        Nokogiri::HTML(controller.view_context.render(component, args, &block)).css("body > *")
       end
 
       def controller

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -8,12 +8,14 @@ class ActionView::ComponentTest < Minitest::Test
   def test_render_inline
     result = render_inline(MyComponent)
 
+    assert_equal trim_result(result.first.to_html), "<div>hello,world!</div>"
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
   def test_render_inline_with_old_helper
     result = render_component(MyComponent)
 
+    assert_equal trim_result(result.first.to_html), "<div>hello,world!</div>"
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
@@ -103,13 +105,13 @@ class ActionView::ComponentTest < Minitest::Test
   def test_renders_partial_template
     result = render_inline(PartialComponent)
 
-    assert_equal "<div>hello,partial world!</div>", result.css("div").first.to_html
+    assert_equal "<div>hello,partial world!</div>", result.first.to_html
   end
 
   def test_renders_content_for_template
     result = render_inline(ContentForComponent)
 
-    assert_equal "<div>Hello content for</div>", result.css("div").first.to_html
+    assert_equal "<div>Hello content for</div>", result.first.to_html
   end
 
   def test_renders_path_helper
@@ -133,38 +135,38 @@ class ActionView::ComponentTest < Minitest::Test
   def test_renders_another_component
     result = render_inline(AnotherComponent)
 
-    assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
+    assert_equal trim_result(result.first.to_html), "<div>hello,world!</div>"
   end
 
   def test_renders_component_with_css_sidecar
     result = render_inline(CssSidecarFileComponent)
 
-    assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
+    assert_equal trim_result(result.first.to_html), "<div>hello,world!</div>"
   end
 
   def test_renders_component_with_request_context
     result = render_inline(RequestComponent)
 
-    assert_equal trim_result(result.css("div").first.to_html), "<div>0.0.0.0</div>"
+    assert_equal trim_result(result.first.to_html), "<div>0.0.0.0</div>"
   end
 
   def test_renders_component_without_format
     result = render_inline(NoFormatComponent)
 
-    assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
+    assert_equal trim_result(result.first.to_html), "<div>hello,world!</div>"
   end
 
   def test_template_changes_are_not_reflected_in_production
     old_value = ActionView::Base.cache_template_loading
     ActionView::Base.cache_template_loading = true
 
-    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).first.to_html
 
     modify_file "app/components/my_component.html.erb", "<div>Goodbye world!</div>" do
-      assert_equal  "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
+      assert_equal  "<div>hello,world!</div>", render_inline(MyComponent).first.to_html
     end
 
-    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).first.to_html
 
     ActionView::Base.cache_template_loading = old_value
   end
@@ -173,13 +175,13 @@ class ActionView::ComponentTest < Minitest::Test
     old_value = ActionView::Base.cache_template_loading
     ActionView::Base.cache_template_loading = false
 
-    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).first.to_html
 
     modify_file "app/components/my_component.html.erb", "<div>Goodbye world!</div>" do
-      assert_equal "<div>Goodbye world!</div>", render_inline(MyComponent).css("div").first.to_html
+      assert_equal "<div>Goodbye world!</div>", render_inline(MyComponent).first.to_html
     end
 
-    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_inline(MyComponent).first.to_html
 
     ActionView::Base.cache_template_loading = old_value
   end
@@ -201,10 +203,10 @@ class ActionView::ComponentTest < Minitest::Test
   end
 
   def test_renders_component_with_translations
-    assert_includes render_inline(TranslationsComponent).css("div").first.to_html,
+    assert_includes render_inline(TranslationsComponent).first.to_html,
                     "<h1>#{I18n.t('components.translations_component.title')}</h1>"
 
-    assert_includes render_inline(TranslationsComponent).css("div").first.to_html,
+    assert_includes render_inline(TranslationsComponent).first.to_html,
                     "<h2>#{I18n.t('components.translations_component.subtitle')}</h2>"
   end
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -5,13 +5,13 @@ require "test_helper"
 class ActionView::ComponentTest < Minitest::Test
   include ActionView::Component::TestHelpers
 
-  def test_render_component
+  def test_render_inline
     result = render_inline(MyComponent)
 
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
-  def test_render_component_with_old_helper
+  def test_render_inline_with_old_helper
     result = render_component(MyComponent)
 
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"


### PR DESCRIPTION
Let Nokogiri point directly at the rendered component instead of requiring the
knowledge about the fact that it's rendered in the context of an HTML document.

A deprecation cycle shouldn't be necessary the change is compatible with the former use (as ensured by the two tests).