### PR TITLE
Deprecation example

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES
   minitest (= 5.1.0)
   rails (= 6.0.0)
   rake (~> 10.0)
-  rubocop (~> 0.59)
+  rubocop (= 0.74)
   rubocop-github (~> 0.13.0)
   slim (~> 4.0)
 

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "= 5.1.0"
   spec.add_development_dependency "haml", "~> 5"
   spec.add_development_dependency "slim", "~> 4.0"
-  spec.add_development_dependency "rubocop", "~> 0.59"
+  spec.add_development_dependency "rubocop", "= 0.74"
   spec.add_development_dependency "rubocop-github", "~> 0.13.0"
 end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -9,7 +9,7 @@ class ActionView::Base
     def render(options = {}, args = {}, &block)
       if options.respond_to?(:render_in)
         ActiveSupport::Deprecation.warn(
-          "passing component instances to (`render MyComponent.new(foo: :bar)`) has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
+          "passing component instances (`render MyComponent.new(foo: :bar)`) has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
         )
 
         options.render_in(self, &block)

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -9,7 +9,7 @@ class ActionView::Base
     def render(options = {}, args = {}, &block)
       if options.respond_to?(:render_in)
         ActiveSupport::Deprecation.warn(
-          "passing component instances to `render` has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
+          "passing component instances to (`render MyComponent.new(foo: :bar)`) has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
         )
 
         options.render_in(self, &block)


### PR DESCRIPTION
This PR gives a more clear example in the argument format deprecation warning.

cc @breim

[Fixes #88]