### PR TITLE
remove ruby 2.3 support, as Actions has removed it

### DIFF
--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -8,16 +8,12 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.0.0, 5.2.3, 6.0.0, master]
-        ruby_version: [2.3.x, 2.4.x, 2.5.x, 2.6.x]
+        ruby_version: [2.4.x, 2.5.x, 2.6.x]
         exclude:
           - rails_version: master
             ruby_version: 2.4.x
-          - rails_version: master
-            ruby_version: 2.3.x
           - rails_version: 6.0.0
             ruby_version: 2.4.x
-          - rails_version: 6.0.0
-            ruby_version: 2.3.x
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As the goal of this gem is to be upstreamed into Rails, it is designed to integr
 
 ## Compatibility
 
-`actionview-component` is tested for compatibility with combinations of Ruby `2.3`/`2.4`/`2.5`/`2.6` and Rails `5.0.0`/`5.2.3`/`6.0.0`/`6.1.0.alpha`.
+`actionview-component` is tested for compatibility with combinations of Ruby `2.4`/`2.5`/`2.6` and Rails `5.0.0`/`5.2.3`/`6.0.0`/`6.1.0.alpha`.
 
 ## Installation
 Add this line to your application's Gemfile:


### PR DESCRIPTION
Actions removed support for Ruby 2.3, and we've not seen this check fail yet, so I think we're OK to remove it for the sake of momentum.