### PR TITLE
explicitly remove extension from path vs splitting on '.'

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -177,7 +177,7 @@ module ActionView
 
         def templates
           @templates ||=
-            (Dir["#{source_location.split(".")[0]}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location]).each_with_object([]) do |path, memo|
+            (Dir["#{source_location.sub(/#{File.extname(source_location)}$/, '')}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location]).each_with_object([]) do |path, memo|
               memo << {
                 path: path,
                 variant: path.split(".").second.split("+")[1]&.to_sym,


### PR DESCRIPTION
Our existing implementation of looking up sibling template files
split the source_location path on '.', assuming that the .rb
file extension was the only place a period was used in the entire
file path. This meant that any component file in a path that contained
other periods failed to find its sibling templates.

I did not include a test here as it seemed difficult to impossible to write one.

[Fixes: #83]

Co-Authored-By: Anton <profox.rus@gmail.com>