### PR TITLE
Add helpers proxy

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -93,6 +93,11 @@ module ActionView
         @controller ||= view_context.controller
       end
 
+      # Provides a proxy to access helper methods through
+      def helpers
+        @helpers ||= view_context
+      end
+
       # Looks for the source file path of the initialize method of the instance's class.
       # Removes the first part of the path and the extension.
       def virtual_path

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -140,6 +140,12 @@ class ActionView::ComponentTest < Minitest::Test
     assert_equal "<div>Hello content for</div>", result.first.to_html
   end
 
+  def test_renders_helper_method_through_proxy
+    result = render_inline(HelpersProxyComponent)
+
+    assert_equal "<div>Hello helper method</div>", result.first.to_html
+  end
+
   def test_renders_path_helper
     result = render_inline(PathComponent)
 

--- a/test/app/components/helpers_proxy_component.html.erb
+++ b/test/app/components/helpers_proxy_component.html.erb
@@ -1,0 +1,1 @@
+<div><%= helpers.message %></div>

--- a/test/app/components/helpers_proxy_component.rb
+++ b/test/app/components/helpers_proxy_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class HelpersProxyComponent < ActionView::Component::Base
+  def initialize(*); end
+end

--- a/test/app/helpers/message_helper.rb
+++ b/test/app/helpers/message_helper.rb
@@ -1,0 +1,5 @@
+module MessageHelper
+  def message
+    "Hello helper method"
+  end
+end

--- a/test/app/helpers/message_helper.rb
+++ b/test/app/helpers/message_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MessageHelper
   def message
     "Hello helper method"


### PR DESCRIPTION
Adds a `#helpers` method that works as a proxy for components to access helper methods through.

Before this PR you'd have to include helpers on a per-module basis:
```ruby
module IconHelper
  def icon name
    tag.i data: { feather: name.to_s.dasherize }
  end
end

UserComponent < ActionView::Component::Base
  include IconHelper

  def profile_icon
    icon :user   
  end
end
```
Now they can be referenced directly through the `#helpers` proxy:
```ruby
UserComponent < ActionView::Component::Base
  def profile_icon
    helpers.icon :user   
  end
end
```
Or delegated, if you prefer:
```ruby
UserComponent < ActionView::Component::Base
  delegate :icon, to: :helpers
  
  def profile_icon
    icon :user   
  end
end
```
---
The proxy pattern makes all helpers available for "free" and prevents our component classes from bloating with all the additional methods from a given helper module that you might not need.

Inspired by a similar feature in Rails by @rafaelfranca: https://github.com/rails/rails/pull/24866

Resolves: #95