### PR TITLE
Remove DummyTemplate

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -31,11 +31,6 @@ end
 module ActionView
   module Component
     class Base < ActionView::Base
-      IDENTIFIER_PLACEHOLDER = ""
-
-      # we'll eventually want to update this to support other types
-      TYPE_PLACEHOLDER = "text/html"
-
       include ActiveModel::Validations
       include ActiveSupport::Configurable
       include ActionController::RequestForgeryProtection
@@ -186,12 +181,13 @@ module ActionView
           templates.map { |template| template[:variant] }
         end
 
+        # we'll eventually want to update this to support other types
         def type
-          TYPE_PLACEHOLDER
+          "text/html"
         end
 
         def identifier
-          IDENTIFIER_PLACEHOLDER
+          ""
         end
 
         private
@@ -230,7 +226,7 @@ module ActionView
           if handler.method(:call).parameters.length > 1
             handler.call(self, template)
           else # remove before upstreaming into Rails
-            handler.call(OpenStruct.new(source: template, identifier: IDENTIFIER_PLACEHOLDER, type: TYPE_PLACEHOLDER))
+            handler.call(OpenStruct.new(source: template, identifier: identifier, type: type))
           end
         end
       end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -240,7 +240,7 @@ module ActionView
       class DummyTemplate
         attr_reader :source
 
-        def initialize(source = nil)
+        def initialize(source)
           @source = source
         end
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -229,8 +229,7 @@ module ActionView
 
           if handler.method(:call).parameters.length > 1
             handler.call(self, template)
-          else
-            # This can be removed once this code is merged into Rails
+          else # remove before upstreaming into Rails
             handler.call(OpenStruct.new(source: template, identifier: IDENTIFIER_PLACEHOLDER, type: TYPE_PLACEHOLDER))
           end
         end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -231,25 +231,8 @@ module ActionView
             handler.call(self, template)
           else
             # This can be removed once this code is merged into Rails
-            handler.call(DummyTemplate.new(template))
+            handler.call(OpenStruct.new(source: template, identifier: IDENTIFIER_PLACEHOLDER, type: TYPE_PLACEHOLDER))
           end
-        end
-      end
-
-      # This can be removed once this code is merged into Rails
-      class DummyTemplate
-        attr_reader :source
-
-        def initialize(source)
-          @source = source
-        end
-
-        def identifier
-          IDENTIFIER_PLACEHOLDER
-        end
-
-        def type
-          TYPE_PLACEHOLDER
         end
       end
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -31,6 +31,9 @@ end
 module ActionView
   module Component
     class Base < ActionView::Base
+      IDENTIFIER_PLACEHOLDER = ""
+      TYPE_PLACEHOLDER = "text/html"
+
       include ActiveModel::Validations
       include ActiveSupport::Configurable
       include ActionController::RequestForgeryProtection
@@ -182,11 +185,11 @@ module ActionView
         end
 
         def type
-          "text/html"
+          TYPE_PLACEHOLDER
         end
 
         def identifier
-          ""
+          IDENTIFIER_PLACEHOLDER
         end
 
         private
@@ -222,15 +225,16 @@ module ActionView
           handler = ActionView::Template.handler_for_extension(File.extname(file_path).gsub(".", ""))
           template = File.read(file_path)
 
-          # This can be removed once this code is merged into Rails
           if handler.method(:call).parameters.length > 1
             handler.call(self, template)
           else
+            # This can be removed once this code is merged into Rails
             handler.call(DummyTemplate.new(template))
           end
         end
       end
 
+      # This can be removed once this code is merged into Rails
       class DummyTemplate
         attr_reader :source
 
@@ -239,12 +243,12 @@ module ActionView
         end
 
         def identifier
-          ""
+          IDENTIFIER_PLACEHOLDER
         end
 
         # we'll eventually want to update this to support other types
         def type
-          "text/html"
+          TYPE_PLACEHOLDER
         end
       end
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -32,6 +32,8 @@ module ActionView
   module Component
     class Base < ActionView::Base
       IDENTIFIER_PLACEHOLDER = ""
+
+      # we'll eventually want to update this to support other types
       TYPE_PLACEHOLDER = "text/html"
 
       include ActiveModel::Validations
@@ -246,7 +248,6 @@ module ActionView
           IDENTIFIER_PLACEHOLDER
         end
 
-        # we'll eventually want to update this to support other types
         def type
           TYPE_PLACEHOLDER
         end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -181,6 +181,14 @@ module ActionView
           templates.map { |template| template[:variant] }
         end
 
+        def type
+          "text/html"
+        end
+
+        def identifier
+          ""
+        end
+
         private
 
         def templates
@@ -216,7 +224,7 @@ module ActionView
 
           # This can be removed once this code is merged into Rails
           if handler.method(:call).parameters.length > 1
-            handler.call(DummyTemplate.new, template)
+            handler.call(self, template)
           else
             handler.call(DummyTemplate.new(template))
           end


### PR DESCRIPTION
As we move to make ActionView::Component::Base behave more like a template, I'm looking to see if we can remove the DummyTemplate class.