### PR TITLE
Removing "components" from virtual path

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -101,10 +101,9 @@ module ActionView
         @helpers ||= view_context
       end
 
-      # Looks for the source file path of the initialize method of the instance's class.
       # Removes the first part of the path and the extension.
       def virtual_path
-        self.class.source_location.gsub(%r{(.*app/)|(\.rb)}, "")
+        self.class.source_location.gsub(%r{(.*app/components)|(\.rb)}, "")
       end
 
       def view_cache_dependencies

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -236,10 +236,10 @@ class ActionView::ComponentTest < Minitest::Test
 
   def test_renders_component_with_translations
     assert_includes render_inline(TranslationsComponent).first.to_html,
-                    "<h1>#{I18n.t('components.translations_component.title')}</h1>"
+                    "<h1>#{I18n.t('translations_component.title')}</h1>"
 
     assert_includes render_inline(TranslationsComponent).first.to_html,
-                    "<h2>#{I18n.t('components.translations_component.subtitle')}</h2>"
+                    "<h2>#{I18n.t('translations_component.subtitle')}</h2>"
   end
 
   def test_renders_component_with_rb_in_its_name

--- a/test/app/components/translations_component.html.erb
+++ b/test/app/components/translations_component.html.erb
@@ -1,4 +1,4 @@
 <div>
   <h1><%= t('.title') %></h1>
-  <h2><%= t('components.translations_component.subtitle') %></h2>
+  <h2><%= t('translations_component.subtitle') %></h2>
 </div>

--- a/test/config/locales/en.yml
+++ b/test/config/locales/en.yml
@@ -1,7 +1,6 @@
 en:
-  components:
-    translations_component:
-      title: Lorem ipsum
-      subtitle: More lorem ipsum
-    editorb_component:
-      title: Editorb!
+  translations_component:
+    title: Lorem ipsum
+    subtitle: More lorem ipsum
+  editorb_component:
+    title: Editorb!


### PR DESCRIPTION
Rails default for translation shortcut paths do not include the parent folder where the translations are used.
For instance, when you use `t('.success')` in a controller, the translation key does not include the `controllers` folder.
Therefore, the word `components` get removed from the virtual path of components.
This will allow us to use `t('.title')` in components and expect the translation key not to include the `components` key as the top level key in the translation yml file.

What happens when the developer uses a different folder for components? The virtual path will just be the location of the file, in other words, the output of `Class#source_location`.