### PR TITLE
Add component suffix to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Content passed to an `ActionView::Component` as a block is captured and assigned
 
 #### Quick start
 
-Use the provided component generator to quickly get going with a new `ActionView::Component`.
+Use the component generator to create a new `ActionView::Component`.
 
-The generator expects the component name and the list of accepted properties as arguments. 
+The generator accepts the component name and the list of accepted properties as arguments:
 
 ```bash
 bin/rails generate component Example title content
       invoke  test_unit
-      create    test/components/example_component_test.rb
+      create  test/components/example_component_test.rb
       create  app/components/example_component.rb
       create  app/components/example_component.html.erb
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Components support ActiveModel validations. Components are validated after initi
 
 Content passed to an `ActionView::Component` as a block is captured and assigned to the `content` accessor.
 
+#### Quick start
+
+Use the provided component generator to quickly get going with a new `ActionView::Component`.
+
+The generator expects the component name and the list of accepted properties as arguments. 
+
+```bash
+bin/rails generate component Example title content
+      invoke  test_unit
+      create    test/components/example_component_test.rb
+      create  app/components/example_component.rb
+      create  app/components/example_component.html.erb
+```
+
 #### Implementation
 
 An `ActionView::Component` is a Ruby file and corresponding template file (in any format supported by Rails) with the same base name:

--- a/lib/rails/generators/component/USAGE
+++ b/lib/rails/generators/component/USAGE
@@ -8,6 +8,6 @@ Example:
     bin/rails generate component Profile name age
 
     creates a Profile component and test:
-        Component:    app/components/profile.rb
-        Template:     app/components/profile.html.erb
-        Test:         test/components/profile_test.rb
+        Component:    app/components/profile_component.rb
+        Template:     app/components/profile_component.html.erb
+        Test:         test/components/profile_component_test.rb

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -7,16 +7,21 @@ module Rails
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       hook_for :test_framework
+      check_class_collision suffix: "Component"
 
       def create_component_file
-        template "component.rb", File.join("app/components",  "#{file_name}.rb")
+        template "component.rb", File.join("app/components",  "#{file_name}_component.rb")
       end
 
       def create_template_file
-        template "component.html.erb", File.join("app/components",  "#{file_name}.html.erb")
+        template "component.html.erb", File.join("app/components",  "#{file_name}_component.html.erb")
       end
 
       private
+
+      def file_name
+        @_file_name ||= super.sub(/_component\z/i, "")
+      end
 
       def requires_content?
         return @requires_content if @asked

--- a/lib/rails/generators/component/templates/component.rb.tt
+++ b/lib/rails/generators/component/templates/component.rb.tt
@@ -1,4 +1,4 @@
-class <%= class_name %> < <%= parent_class %>
+class <%= class_name %>Component < <%= parent_class %>
   <%- if requires_content? -%>
   validates :content, presence: true
   <%- end -%>

--- a/lib/rails/generators/test_unit/component_generator.rb
+++ b/lib/rails/generators/test_unit/component_generator.rb
@@ -4,9 +4,16 @@ module TestUnit
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
+      check_class_collision suffix: "ComponentTest"
 
       def create_test_file
-        template "component_test.rb", File.join("test/components",  "#{file_name}_test.rb")
+        template "component_test.rb", File.join("test/components", "#{file_name}_component_test.rb")
+      end
+
+      private
+
+      def file_name
+        @_file_name ||= super.sub(/_component\z/i, "")
       end
     end
   end

--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class <%= class_name %>Test < ActiveSupport::TestCase
+class <%= class_name %>ComponentTest < ActiveSupport::TestCase
   test "component renders something useful" do
     # assert_equal(
     #   %(<span title="my title">Hello, components!</span>),


### PR DESCRIPTION
Closes #110.

This PR does two things:

1. While going through the README I realized that the desire is for components to be suffixed with component (for class and file names). My apologies, I missed that in the initial implementation. The first commit adds the component suffix to all files and classes.
2. Adds the Quick start section for creating a component using the generator.