### PR TITLE
Pre-compile templates

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -157,8 +157,8 @@ module ActionView
         end
 
         # Compile templates to instance methods, assuming they haven't been compiled already.
-        # We could in theory do this on app boot, at least in production environments.
-        # Right now this just compiles the first time the component is rendered.
+        #
+        # Templates are pre-compiled during startup when eager loading is enabled in the app.
         def compile
           return if @compiled && ActionView::Base.cache_template_loading
 

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -42,6 +42,12 @@ module ActionView
         end
       end
 
+      initializer "action_view_component.compile_templates" do
+        ActiveSupport.on_load(:after_initialize) do
+          ActionView::Component::Base.descendants.each(&:compile) if config.eager_load
+        end
+      end
+
       config.after_initialize do |app|
         options = app.config.action_view_component
 


### PR DESCRIPTION
This PR introduces pre-compilation of component templates during app launch.

I would've liked to write a test for this, but I'm not sure if it's feasible to test something that depends on eager loading inside an initializer, concisely?

Resolves: #100