### PR TITLE
Include test helpers in generator template

### DIFF
--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class <%= class_name %>ComponentTest < ActiveSupport::TestCase
+  include ActionView::Component::TestHelpers
+
   test "component renders something useful" do
     # assert_equal(
     #   %(<span title="my title">Hello, components!</span>),


### PR DESCRIPTION
This PR includes a missing module to generated test cases

I noticed the test helpers aren't included in the generator test case template. I went ahead and included the module, as `render_inline` is defined in  `ActionView::Component::TestHelpers`.