### PR TITLE
explicitly require actionview/component/base in tests

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_model"
+require "active_support/configurable"
 require_relative "preview"
 
 # Monkey patch ActionView::Base#render to support ActionView::Component
@@ -33,8 +35,9 @@ module ActionView
     class Base < ActionView::Base
       include ActiveModel::Validations
       include ActiveSupport::Configurable
-      include ActionController::RequestForgeryProtection
       include ActionView::Component::Previews
+
+      delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
       validate :variant_exists
 

--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/concern"
 require "active_support/descendants_tracker"
 require_relative "test_helpers"
 

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "active_job/railtie"
-require "action_view"
-require "rails"
 require "railties/lib/rails/components_controller"
 require "railties/lib/rails/component_examples_controller"
 

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -9,9 +9,10 @@ module ActionView
       config.action_view_component = ActiveSupport::OrderedOptions.new
       config.eager_load_namespaces << ActionView::Component
 
-      initializer "action_view_component.logger" do
-        ActiveSupport.on_load(:action_view_component) { self.logger ||= Rails.logger }
-      end
+      # Disabled due to issues with ActionView::Component::Base not defining .logger
+      # initializer "action_view_component.logger" do
+      #   ActiveSupport.on_load(:action_view_component) { self.logger ||= Rails.logger }
+      # end
 
       initializer "action_view_component.set_configs" do |app|
         options = app.config.action_view_component

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -92,11 +92,16 @@ class ActionView::ComponentTest < Minitest::Test
   end
 
   def test_renders_button_to_component
+    old_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
     result = render_inline(ButtonToComponent) { "foo" }
 
     assert_equal '<input type="submit" value="foo">', result.css("input[type=submit]").to_html
     assert result.css("form[class='button_to'][action='/'][method='post']").present?
     assert result.css("input[type='hidden'][name='authenticity_token']").present?
+
+    ActionController::Base.allow_forgery_protection = old_value
   end
 
   def test_renders_component_with_variant

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,7 @@
 require "bundler/setup"
 require "pp"
 require "pathname"
-root_path = Pathname(File.expand_path("../..", __FILE__))
-$LOAD_PATH.unshift root_path.join("lib").to_s
+require "action_view/component/base"
 require "minitest/autorun"
 require "action_view/component/test_helpers"
 


### PR DESCRIPTION
This PR refactors our require structure to better
mimic how the gem is required in applications.

@kaspermeyer this might be of use in your work on compiling on init.