### PR TITLE
Fix issue with generating component initiatilze_signature from attributes

### DIFF
--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -36,7 +36,7 @@ module Rails
 
       def initialize_signature
         if attributes.present?
-          attributes.map(&:name).join(":, ")
+          attributes.map { |attr| "#{attr.name}:" }.join(", ")
         else
           "*"
         end


### PR DESCRIPTION
Issue
======
ComponentGenerator creates component with broken parameters leaving off a `:` on the last attribute. For example `rails g component Example hello world` generates:

```ruby
class ButtonComponent < ActionView::Component::Base

  def initialize(hello:, world)
.....
```

Solution
======
@dylnclrk and I altered the `#map` method in `ComponentGenerator#initialize_signature` to append the `:` and then join the array with `, `.

_NOTE_: We did not add a test for this case since there are no established patterns for testing the generators.