### PR TITLE
consolidate require's into a single loader file for the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ bundle
 In `config/application.rb`, add:
 
 ```bash
-require "action_view/component/base"
+require "action_view/component"
 ```
 
 ## Guide

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -1,0 +1,3 @@
+require "action_view/component/monkey_patch"
+require "action_view/component/base"
+require "action_view/component/railtie"

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_view/component/monkey_patch"
 require "action_view/component/base"
 require "action_view/component/railtie"

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -1,38 +1,13 @@
 # frozen_string_literal: true
 
 require "active_model"
+require "action_view"
 require "active_support/configurable"
 require_relative "preview"
 
-# Monkey patch ActionView::Base#render to support ActionView::Component
-#
-# A version of this monkey patch was upstreamed in https://github.com/rails/rails/pull/36388
-# We'll need to upstream an updated version of this eventually.
-class ActionView::Base
-  module RenderMonkeyPatch
-    def render(options = {}, args = {}, &block)
-      if options.respond_to?(:render_in)
-        ActiveSupport::Deprecation.warn(
-          "passing component instances (`render MyComponent.new(foo: :bar)`) has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
-        )
-
-        options.render_in(self, &block)
-      elsif options.is_a?(Class) && options < ActionView::Component::Base
-        options.new(args).render_in(self, &block)
-      elsif options.is_a?(Hash) && options.has_key?(:component)
-        options[:component].new(options[:locals]).render_in(self, &block)
-      else
-        super
-      end
-    end
-  end
-
-  prepend RenderMonkeyPatch
-end
-
 module ActionView
   module Component
-    class Base < ActionView::Base
+    class Base < ::ActionView::Base
       include ActiveModel::Validations
       include ActiveSupport::Configurable
       include ActionView::Component::Previews

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -7,7 +7,7 @@ require_relative "preview"
 
 module ActionView
   module Component
-    class Base < ::ActionView::Base
+    class Base < ActionView::Base
       include ActiveModel::Validations
       include ActiveSupport::Configurable
       include ActionView::Component::Previews

--- a/lib/action_view/component/monkey_patch.rb
+++ b/lib/action_view/component/monkey_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey patch ActionView::Base#render to support ActionView::Component
 #
 # A version of this monkey patch was upstreamed in https://github.com/rails/rails/pull/36388

--- a/lib/action_view/component/monkey_patch.rb
+++ b/lib/action_view/component/monkey_patch.rb
@@ -1,0 +1,25 @@
+# Monkey patch ActionView::Base#render to support ActionView::Component
+#
+# A version of this monkey patch was upstreamed in https://github.com/rails/rails/pull/36388
+# We'll need to upstream an updated version of this eventually.
+class ActionView::Base
+  module RenderMonkeyPatch
+    def render(options = {}, args = {}, &block)
+      if options.respond_to?(:render_in)
+        ActiveSupport::Deprecation.warn(
+          "passing component instances (`render MyComponent.new(foo: :bar)`) has been deprecated and will be removed in v2.0.0. Use `render MyComponent, foo: :bar` instead."
+        )
+
+        options.render_in(self, &block)
+      elsif options.is_a?(Class) && options < ActionView::Component::Base
+        options.new(args).render_in(self, &block)
+      elsif options.is_a?(Hash) && options.has_key?(:component)
+        options[:component].new(options[:locals]).render_in(self, &block)
+      else
+        super
+      end
+    end
+  end
+
+  prepend RenderMonkeyPatch
+end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -5,8 +5,7 @@ require File.expand_path("../boot", __FILE__)
 require "active_model/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
-require "action_view/component/base"
-require "action_view/component/railtie"
+require "action_view/component"
 require "sprockets/railtie"
 
 require "haml"


### PR DESCRIPTION
In trying to setup component previews in the
actionview-component-demo repo, I realized that we were
requiring users of this gem to explicitly require the railtie
in order for them to work.

This PR moves us towards a more typical gem structure
where a single entry file, lib/action_view/component.rb,
loads the rest of the gem.

This big of a change should probably prompt us to make a minor release version bump.

cc @kaspermeyer @juanmanuelramallo 