### PR TITLE
Remove eager loading registration

### DIFF
--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -7,7 +7,6 @@ module ActionView
   module Component
     class Railtie < Rails::Railtie # :nodoc:
       config.action_view_component = ActiveSupport::OrderedOptions.new
-      config.eager_load_namespaces << ActionView::Component
 
       # Disabled due to issues with ActionView::Component::Base not defining .logger
       # initializer "action_view_component.logger" do


### PR DESCRIPTION
This PR removes eager loading registration that caused Rails to raise an exception on application boot when eager loading was turned on.