### PR TITLE
Add rudimentary RSpec support to the component generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ end
 
 Specs created by the generator should now have access to test helpers like `render_inline`.
 
-To use component previews, you'll want to [configure the preview path](#previewing-components) so that preview
+To use component previews add this into your application.rb: `config.action_view_component.preview_path = "#{Rails.root}/spec/components/previews"`
 classes live somewhere besides the `test/` directory which is not present when RSpec is used.
 
 ## Frequently Asked Questions

--- a/README.md
+++ b/README.md
@@ -278,8 +278,11 @@ end
 
 Specs created by the generator should now have access to test helpers like `render_inline`.
 
-To use component previews add this into your application.rb: `config.action_view_component.preview_path = "#{Rails.root}/spec/components/previews"`
-classes live somewhere besides the `test/` directory which is not present when RSpec is used.
+To use component previews, set the following in `config/application.rb`:
+
+```ruby
+config.action_view_component.preview_path = "#{Rails.root}/spec/components/previews"
+```
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ For example, if you want to use `lib/component_previews`, set the following in `
 config.action_view_component.preview_path = "#{Rails.root}/lib/component_previews"
 ```
 
+### Setting up RSpec
+
+If you're using RSpec, you can configure component specs to have access to test helpers. Create
+`spec/support/actionview_component.rb` with:
+
+```ruby
+require "action_view/component/test_helpers"
+
+RSpec.configure do |config|
+    # Ensure that the test helpers are available in component specs
+    config.include ActionView::Component::TestHelpers, type: :component
+end
+```
+
+And then ensure it's required in `spec/rails_helper.rb`. Specs created by the generator should now have access to the
+test helpers like `render_inline`.
+
 ## Frequently Asked Questions
 
 ### Can I use other templating languages besides ERB?

--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ end
 
 Specs created by the generator should now have access to test helpers like `render_inline`.
 
+To use component previews, you'll want to [configure the preview path](#previewing-components) so that preview
+classes live somewhere besides the `test/` directory which is not present when RSpec is used.
+
 ## Frequently Asked Questions
 
 ### Can I use other templating languages besides ERB?

--- a/README.md
+++ b/README.md
@@ -262,20 +262,21 @@ config.action_view_component.preview_path = "#{Rails.root}/lib/component_preview
 
 ### Setting up RSpec
 
-If you're using RSpec, you can configure component specs to have access to test helpers. Create
-`spec/support/actionview_component.rb` with:
+If you're using RSpec, you can configure component specs to have access to test helpers. Add the following to
+`spec/rails_helper.rb`:
 
 ```ruby
 require "action_view/component/test_helpers"
 
 RSpec.configure do |config|
+    # ...
+
     # Ensure that the test helpers are available in component specs
     config.include ActionView::Component::TestHelpers, type: :component
 end
 ```
 
-And then ensure it's required in `spec/rails_helper.rb`. Specs created by the generator should now have access to the
-test helpers like `render_inline`.
+Specs created by the generator should now have access to test helpers like `render_inline`.
 
 ## Frequently Asked Questions
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Rspec
+  module Generators
+    class ComponentGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path("templates", __dir__)
+
+      def create_test_file
+        template "component_spec.rb", File.join("spec/components", "#{file_name}_component_spec.rb")
+      end
+
+      private
+
+      def file_name
+        @_file_name ||= super.sub(/_component\z/i, "")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/rspec/templates/component_spec.rb.tt
+++ b/lib/rails/generators/rspec/templates/component_spec.rb.tt
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe <%= class_name %>Component, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class, attr: "value") { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
## Motivation

The component generator does not support RSpec. 

When a project is configured to use RSpec and the component generator is run, no spec is created.

## Solution

@rdavid1099 and I added an RSpec hook to the component generator to create a corresponding spec. We also added some instructions to the README about configuring RSpec to include test helpers like `#render_inline`. 

## Open questions

* Does this functionality belong in actionview-component?
  * This seems useful to include, as establishing patterns for testing components with RSpec will be valuable for a number of users.
  * However, the RSpec generators and configuration should probably be moved in to rspec-rails when actionview-component is provided by Rails, as rails does not include RSpec generators.
* How can we test changes like this to generators? 
  * I'm not sure I know of an example of doing so.

