### PR TITLE
Fix edge case issue with extracting variants from less conventional source_locations

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -169,9 +169,13 @@ module ActionView
 
         private
 
+        def matching_views_in_source_location
+          (Dir["#{source_location.sub(/#{File.extname(source_location)}$/, '')}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location])
+        end
+
         def templates
           @templates ||=
-            (Dir["#{source_location.sub(/#{File.extname(source_location)}$/, '')}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location]).each_with_object([]) do |path, memo|
+            matching_views_in_source_location.each_with_object([]) do |path, memo|
               pieces = File.basename(path).split(".")
 
               memo << {

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -172,10 +172,12 @@ module ActionView
         def templates
           @templates ||=
             (Dir["#{source_location.sub(/#{File.extname(source_location)}$/, '')}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location]).each_with_object([]) do |path, memo|
+              pieces = File.basename(path).split(".")
+
               memo << {
                 path: path,
-                variant: path.split(".").second.split("+")[1]&.to_sym,
-                handler: path.split(".").last
+                variant: pieces.second.split("+")[1]&.to_sym,
+                handler: pieces.last
               }
             end
         end

--- a/test/action_view/component/base/unit_test.rb
+++ b/test/action_view/component/base/unit_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionView::Component::Base::UnitTest < Minitest::Test
+  def test_templates_parses_all_types_of_paths
+    file_path = [
+      "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",
+      "/_underscore-dash./component/test_component.html+desktop.slim",
+      "/tilda~/component/test_component.html.haml"
+    ]
+    expected = [
+      {variant: :phone, handler: "erb"},
+      {variant: :desktop, handler: "slim"},
+      {variant: nil, handler: "haml"}
+    ]
+
+    ActionView::Component::Base.stub(:matching_views_in_source_location, file_path) do
+      templates = ActionView::Component::Base.send(:templates)
+
+      templates.each_with_index do |template, index|
+        assert_equal(template[:path], file_path[index])
+        assert_equal(template[:variant], expected[index][:variant])
+        assert_equal(template[:handler], expected[index][:handler])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem
=======
I encountered an edge case when trying to use variants. My local development environment has an additional `.` in it (`/example/fake.user/path/to/actionview-component`). The extracting the variant from the `source_location` assumes the path only has `.` in the respective files (`path.split(".").second.split("+")[1]&.to_sym`).

Solution
=======
Using similar patterns to how Rails extracts the variants from views (https://github.com/rails/rails/blob/d2e8b839d2e7236b5f85797f239b01ca2e783024/actionview/lib/action_view/template/resolver.rb#L272), I altered the extraction of the variants in `ActionView::Component::Base#templates`.

_Note_: I did not add any tests for this edge case since, at first, four tests dealing with variants were failing in my local environment. The fix applied has all tests now passing.