### PR TITLE
Disable initializer `action_view_component.eager_load_actions`

### DIFF
--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -41,11 +41,12 @@ module ActionView
         end
       end
 
-      initializer "action_view_component.eager_load_actions" do
-        ActiveSupport.on_load(:after_initialize) do
-          ActionView::Component::Base.descendants.each(&:action_methods) if config.eager_load
-        end
-      end
+      # Disabled because `ActionView::Component::Base` doesn't implement `#action_methods`
+      # initializer "action_view_component.eager_load_actions" do
+      #   ActiveSupport.on_load(:after_initialize) do
+      #     ActionView::Component::Base.descendants.each(&:action_methods) if config.eager_load
+      #   end
+      # end
 
       config.after_initialize do |app|
         options = app.config.action_view_component


### PR DESCRIPTION
This PR disables an initializer that crashes when eager loading is enabled.

Since attempts to eager load are already disabled for now (https://github.com/github/actionview-component/commit/6dc979793d5eb29478f3fcbfd7408405e767254a) I think it makes sense to disable this initializer as well. When its intent has been sorted out and I get started working on strategies to enable eager/autoloading, it'll probably make sense to enable it again.

Resolves: #126