### PR TITLE
require controllers as part of setting autoload paths

### DIFF
--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "railties/lib/rails/components_controller"
-require "railties/lib/rails/component_examples_controller"
-
 module ActionView
   module Component
     class Railtie < Rails::Railtie # :nodoc:
@@ -28,6 +25,9 @@ module ActionView
       end
 
       initializer "action_view_component.set_autoload_paths" do |app|
+        require "railties/lib/rails/components_controller"
+        require "railties/lib/rails/component_examples_controller"
+
         options = app.config.action_view_component
 
         if options.show_previews && options.preview_path

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -5,11 +5,6 @@ module ActionView
     class Railtie < Rails::Railtie # :nodoc:
       config.action_view_component = ActiveSupport::OrderedOptions.new
 
-      # Disabled due to issues with ActionView::Component::Base not defining .logger
-      # initializer "action_view_component.logger" do
-      #   ActiveSupport.on_load(:action_view_component) { self.logger ||= Rails.logger }
-      # end
-
       initializer "action_view_component.set_configs" do |app|
         options = app.config.action_view_component
 
@@ -40,13 +35,6 @@ module ActionView
           config.compile_methods! if config.respond_to?(:compile_methods!)
         end
       end
-
-      # Disabled because `ActionView::Component::Base` doesn't implement `#action_methods`
-      # initializer "action_view_component.eager_load_actions" do
-      #   ActiveSupport.on_load(:after_initialize) do
-      #     ActionView::Component::Base.descendants.each(&:action_methods) if config.eager_load
-      #   end
-      # end
 
       config.after_initialize do |app|
         options = app.config.action_view_component


### PR DESCRIPTION
Having these requires at the top of the file broke our local
dev environment. I found it hard to write a test for this, but it
worked locally for me.