### PR TITLE
Eliminate sqlite dependency

### DIFF
--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -22,7 +22,6 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Build and test with Rake
       run: |
-        sudo apt-get install libsqlite3-dev
         gem install bundler:1.14.0
         bundle update
         bundle install --jobs 4 --retry 3

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,5 @@ build-iPhoneSimulator/
 # .ruby-version
 # .ruby-gemset
 
-/**/*.sqlite3
-
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gemspec
 rails_version = "#{ENV['RAILS_VERSION'] || '6.0.0'}"
 
 gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version
-gem "sqlite3", rails_version >= "6.0.0" ? ">= 1.4.0" : "< 1.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -172,7 +171,6 @@ DEPENDENCIES
   rubocop (= 0.74)
   rubocop-github (~> 0.13.0)
   slim (~> 4.0)
-  sqlite3 (>= 1.4.0)
 
 BUNDLED WITH
    1.17.3

--- a/test/app/models/application_record.rb
+++ b/test/app/models/application_record.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/test/app/models/post.rb
+++ b/test/app/models/post.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
-class Post < ApplicationRecord
+class Post
+  include ActiveModel::Model
+
+  attr_accessor :title
 end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -2,7 +2,6 @@
 
 require File.expand_path("../boot", __FILE__)
 
-require "active_record/railtie"
 require "active_model/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"

--- a/test/config/database.yml
+++ b/test/config/database.yml
@@ -1,8 +1,0 @@
-default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-test:
-  <<: *default
-  database: db/test.sqlite3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,11 +16,3 @@ require "rails/test_help"
 def trim_result(html)
   html.delete(" \t\r\n")
 end
-
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-
-ActiveRecord::Schema.define do
-  create_table :posts, force: true do |t|
-    t.string :title
-  end
-end


### PR DESCRIPTION
In #129, `to_component_class` support was added, to allow an Active Model instance to be conveniently rendered using an associated component class.

However, this work initially targeted ActiveRecord, which necessitated a dependency on sqlite for testing. This dependency can be eliminated by using Active model (instead of ActiveRecord) in the tests.