### PR TITLE
Use source location as identifier

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -164,7 +164,7 @@ module ActionView
         end
 
         def identifier
-          ""
+          source_location
         end
 
         private


### PR DESCRIPTION
I'm working to add components to one of our projects and stumbled upon an incompatibility with one of our gems.

The gem is [better_hml](https://github.com/Shopify/better-html) and the exact line is [here](https://github.com/Shopify/better-html/blob/b5eb06f1f98b7d8d401a61afa6a62d3f2b090f4a/lib/better_html/better_erb.rb#L43).

It uses the template identifier to figure out the extension of the file.

I looked at Rails to try to understand what the template identifier usually is and it seemed to me that it was just the file path. I'm unsure if this would case any problems for the gem or why it was an empty string before, so please do provide feedback.

With this fix, I'm able to render components in our project 😄.