### PR TITLE
Fallback to default template if there is no template defined for a variant

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -53,7 +53,13 @@ module ActionView
         @content = view_context.capture(&block) if block_given?
         validate!
 
-        send(self.class.call_method_name(@variant))
+        call_method_name = if self.respond_to?(self.class.call_method_name(@variant))
+          self.class.call_method_name(@variant)
+        else
+          "call"
+        end
+
+        send(call_method_name)
       ensure
         @current_template = old_current_template
       end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -14,8 +14,6 @@ module ActionView
 
       delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
-      validate :variant_exists
-
       # Entrypoint for rendering components. Called by ActionView::Base#render.
       #
       # view_context: ActionView context from calling view
@@ -93,12 +91,6 @@ module ActionView
       end
 
       private
-
-      def variant_exists
-        return if self.class.variants.include?(@variant) || @variant.nil?
-
-        errors.add(:variant, "'#{@variant}' has no template defined")
-      end
 
       def request
         @request ||= controller.request

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -43,16 +43,6 @@ class ActionView::ComponentTest < Minitest::Test
     assert_includes error.message, "More than one template found for variant 'test' in TooManySidecarFilesForVariantComponent"
   end
 
-  def test_raises_error_when_variant_template_is_not_present
-    with_variant :phone do
-      error = assert_raises ActiveModel::ValidationError do
-        render_inline(MyComponent)
-      end
-
-      assert_includes error.message, "Validation failed: Variant 'phone' has no template defined"
-    end
-  end
-
   def test_raises_error_when_initializer_is_not_defined
     exception = assert_raises NotImplementedError do
       render_inline(MissingInitializerComponent)

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -102,6 +102,14 @@ class ActionView::ComponentTest < Minitest::Test
     end
   end
 
+  def test_renders_default_template_when_variant_template_is_not_present
+    with_variant :variant_without_template do
+      result = render_inline(VariantsComponent)
+
+      assert_includes result.text, "Default"
+    end
+  end
+
   def test_renders_erb_template
     result = render_inline(ErbComponent, message: "bar") { "foo" }
 


### PR DESCRIPTION
After poking around for a bit, I found a very simple change to implement this feature (#141). I'm not a big fan of the change though – it looks and feels bad – and so I'm not sure this PR should be merged 😉 Perhaps instead it can form the basis for a discussion on the way rendering is handled. 

To me it seems we could rely more on `ActionView` to do the heavy lifting around template lookups and rendering, although it's very possible I'm missing some important nuances, as this is my first time taking a look at the codebase.