### PR TITLE
Generate test with new naming convention

### DIFF
--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -6,7 +6,7 @@ class <%= class_name %>ComponentTest < ActiveSupport::TestCase
   test "component renders something useful" do
     # assert_equal(
     #   %(<span title="my title">Hello, components!</span>),
-    #   render_inline(<%= class_name %>, attr: "value") { "Hello, components!" }.css("span").to_html
+    #   render_inline(<%= class_name %>Component, attr: "value") { "Hello, components!" }.css("span").to_html
     # )
   end
 end

--- a/test/action_view/generator_test.rb
+++ b/test/action_view/generator_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require_relative File.expand_path("../../../lib/rails/generators/test_unit/component_generator", __FILE__)
+
+class ActionView::GeneratorTest < ::Rails::Generators::TestCase
+  tests TestUnit::Generators::ComponentGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  setup do
+    run_generator %w(Dummy data)
+  end
+
+  teardown do
+    File.delete File.expand_path("../../tmp/test/components/dummy_component_test.rb", __FILE__)
+  end
+
+  test "generates component" do
+    assert_file "../tmp/test/components/dummy_component_test.rb" do |content|
+      assert_match(/render_inline\(DummyComponent, attr: "value"\) { "Hello, components!" }.css\("span"\).to_html/, content)
+    end
+  end
+end

--- a/test/action_view/test_unit_generator_test.rb
+++ b/test/action_view/test_unit_generator_test.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative File.expand_path("../../../lib/rails/generators/test_unit/component_generator", __FILE__)
 
-class ActionView::GeneratorTest < ::Rails::Generators::TestCase
+class ActionView::TestUnitGeneratorTest < ::Rails::Generators::TestCase
   tests TestUnit::Generators::ComponentGenerator
   destination File.expand_path("../tmp", File.dirname(__FILE__))
 


### PR DESCRIPTION
Test was created with `render_inline(Thing)` which should be `render_inline(ThingComponent)`.

Also created very basic testcase for generator.