### PR TITLE
Avoid dropping elements in the render_inline test helper and adjust tests

### DIFF
--- a/lib/action_view/component/test_helpers.rb
+++ b/lib/action_view/component/test_helpers.rb
@@ -4,7 +4,7 @@ module ActionView
   module Component
     module TestHelpers
       def render_inline(component, **args, &block)
-        Nokogiri::HTML(controller.view_context.render(component, args, &block)).css("body > *")
+        Nokogiri::HTML.fragment(controller.view_context.render(component, args, &block))
       end
 
       def controller

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -6,7 +6,13 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   test "rendering component in a view" do
     get "/"
     assert_response :success
-    assert_equal trim_result(response.body), "<span><div>Foobar</div></span>"
+    assert_html_matches <<~HTML, response.body
+      <span><div>
+        Foo
+        bar
+      </div>
+      </span>
+    HTML
   end
 
   test "rendering component with content" do
@@ -20,53 +26,71 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   test "rendering component in a view with component: syntax" do
     get "/component"
     assert_response :success
-    assert_equal trim_result(response.body), "<span><div>Foobar</div></span>"
+    assert_html_matches <<~HTML, response.body
+      <span><div>
+        Foo
+        bar
+      </div>
+      </span>
+    HTML
   end
 
   test "rendering component with a partial" do
     get "/partial"
     assert_response :success
-    assert_equal trim_result(response.body), "partial:<div>hello,partialworld!</div>component:<div>hello,partialworld!</div><div>hello,partialworld!</div>"
+    assert_html_matches <<~HTML, response.body
+      partial:<div>hello,partial world!</div>
+
+      component:<div>hello,partial world!</div>
+
+      <div>hello,partial world!</div>
+    HTML
   end
 
   test "rendering component with deprecated syntax" do
     get "/deprecated"
     assert_response :success
-    assert_equal trim_result(response.body), "<span><div>Foobar</div></span>"
+    assert_html_matches <<~HTML, response.body
+      <span><div>
+        Foo
+        bar
+      </div>
+      </span>
+    HTML
   end
 
   test "rendering component without variant" do
     get "/variants"
     assert_response :success
-    assert_equal "Default", trim_result(response.body)
+    assert_html_matches "Default", response.body
   end
 
   test "rendering component with tablet variant" do
     get "/variants?variant=tablet"
     assert_response :success
-    assert_equal "Tablet", trim_result(response.body)
+    assert_html_matches "Tablet", response.body
   end
 
   test "rendering component several times with different variants" do
     get "/variants?variant=tablet"
     assert_response :success
-    assert_equal "Tablet", trim_result(response.body)
+    assert_html_matches "Tablet", response.body
 
     get "/variants?variant=phone"
     assert_response :success
-    assert_equal "Phone", trim_result(response.body)
+    assert_html_matches "Phone", response.body
 
     get "/variants"
     assert_response :success
-    assert_equal "Default", trim_result(response.body)
+    assert_html_matches "Default", response.body
 
     get "/variants?variant=tablet"
     assert_response :success
-    assert_equal "Tablet", trim_result(response.body)
+    assert_html_matches "Tablet", response.body
 
     get "/variants?variant=phone"
     assert_response :success
-    assert_equal "Phone", trim_result(response.body)
+    assert_html_matches "Phone", response.body
   end
 
   test "rendering component with caching" do
@@ -75,11 +99,11 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     get "/cached"
     assert_response :success
-    assert_equal "Cached", trim_result(response.body)
+    assert_html_matches "Cached", response.body
 
     get "/cached"
     assert_response :success
-    assert_equal "Cached", trim_result(response.body)
+    assert_html_matches "Cached", response.body
 
     ActionController::Base.perform_caching = false
     Rails.cache.clear

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,22 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../config/environment.rb", __FILE__)
 require "rails/test_help"
 
-def trim_result(html)
-  html.delete(" \t\r\n")
+def trim_result(content)
+  content = content.to_s.lines.collect(&:strip).join("\n").strip
+
+  doc = Nokogiri::HTML.fragment(content)
+
+  doc.xpath("//text()").each do |node|
+    if node.content.match?(/\S/)
+      node.content = node.content.gsub(/\s+/, " ").strip
+    else
+      node.remove
+    end
+  end
+
+  doc.to_s.strip
+end
+
+def assert_html_matches(expected, actual)
+  assert_equal(trim_result(expected), trim_result(actual))
 end


### PR DESCRIPTION
The main thrust of this change is to avoid dropping elements by using
`.css("body > *")`, which will strip out some elements in some
situations and produce unexpected test results. At the same time, we'll
clean up some tests to ensure that whitespace stripping is more
consistent and test arguments are given in a more consistent order.

Fixes #145.