### PR TITLE
Variant template fallback

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -53,7 +53,13 @@ module ActionView
         @content = view_context.capture(&block) if block_given?
         validate!
 
-        send(self.class.call_method_name(@variant))
+        call_method_name = if self.respond_to?(self.class.call_method_name(@variant))
+          self.class.call_method_name(@variant)
+        else
+          "call"
+        end
+
+        send(call_method_name)
       ensure
         @current_template = old_current_template
       end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -53,13 +53,7 @@ module ActionView
         @content = view_context.capture(&block) if block_given?
         validate!
 
-        call_method_name = if self.respond_to?(self.class.call_method_name(@variant))
-          self.class.call_method_name(@variant)
-        else
-          "call"
-        end
-
-        send(call_method_name)
+        send(self.class.call_method_name(@variant))
       ensure
         @current_template = old_current_template
       end
@@ -112,7 +106,7 @@ module ActionView
         end
 
         def call_method_name(variant)
-          if variant.present?
+          if variant.present? && variants.include?(variant)
             "call_#{variant}"
           else
             "call"

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -14,8 +14,6 @@ module ActionView
 
       delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
-      validate :variant_exists
-
       # Entrypoint for rendering components. Called by ActionView::Base#render.
       #
       # view_context: ActionView context from calling view
@@ -93,12 +91,6 @@ module ActionView
       end
 
       private
-
-      def variant_exists
-        return if self.class.variants.include?(@variant) || @variant.nil?
-
-        errors.add(:variant, "'#{@variant}' has no template defined")
-      end
 
       def request
         @request ||= controller.request

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -43,16 +43,6 @@ class ActionView::ComponentTest < Minitest::Test
     assert_includes error.message, "More than one template found for variant 'test' in TooManySidecarFilesForVariantComponent"
   end
 
-  def test_raises_error_when_variant_template_is_not_present
-    with_variant :phone do
-      error = assert_raises ActiveModel::ValidationError do
-        render_inline(MyComponent)
-      end
-
-      assert_includes error.message, "Validation failed: Variant 'phone' has no template defined"
-    end
-  end
-
   def test_raises_error_when_initializer_is_not_defined
     exception = assert_raises NotImplementedError do
       render_inline(MissingInitializerComponent)

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -102,6 +102,14 @@ class ActionView::ComponentTest < Minitest::Test
     end
   end
 
+  def test_renders_default_template_when_variant_template_is_not_present
+    with_variant :variant_without_template do
+      result = render_inline(VariantsComponent)
+
+      assert_includes result.text, "Default"
+    end
+  end
+
   def test_renders_erb_template
     result = render_inline(ErbComponent, message: "bar") { "foo" }
 


### PR DESCRIPTION
Shout out to @asgerb; this is practically a clone of #142, but with one commit from me that moves the logic to `ActionView::Component::Base.call_method_name` per [Joel's comment](https://github.com/github/actionview-component/pull/142#discussion_r354556290).