### PR TITLE
feat(previews): pass content block when rendering

### DIFF
--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -30,8 +30,8 @@ module ActionView
       extend ActiveSupport::DescendantsTracker
       include ActionView::Component::TestHelpers
 
-      def render(component, *locals)
-        render_inline(component, *locals)
+      def render(component, *locals, &block)
+        render_inline(component, *locals, &block)
       end
 
       class << self

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -103,6 +103,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "More lorem..."
   end
 
+  test "renders preview component with content preview" do
+    get "/rails/components/preview_component/with_content"
+
+    assert_includes response.body, "some content"
+  end
+
   test "renders badge component open preview" do
     get "/rails/components/issues/badge_component/open"
 

--- a/test/app/components/preview_component.html.erb
+++ b/test/app/components/preview_component.html.erb
@@ -4,4 +4,8 @@
   <% if cta %>
     <button class="btn"><%= cta %></button>
   <% end %>
+
+  <% if content %>
+    <div><%= content %></div>
+  <% end %>
 </div>

--- a/test/test/components/previews/preview_component_preview.rb
+++ b/test/test/components/previews/preview_component_preview.rb
@@ -8,4 +8,8 @@ class PreviewComponentPreview < ActionView::Component::Preview
   def without_cta
     render(PreviewComponent, title: "More lorem...")
   end
+
+  def with_content
+    render(PreviewComponent, title: "title") { "some content" }
+  end
 end


### PR DESCRIPTION
Allow component previews to use content that is passed to the `render` function as a block.