### PR TITLE
Fixed require path in installation guide [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ bundle
 In `config/application.rb`, add:
 
 ```bash
-require "action_view/component/railtie"
+require "action_view/component/"
 ```
 
 ## Guide


### PR DESCRIPTION
## Description

First of all, thank you for creating a nice gem.
I was trying this and ran into one problem.

If you describe require in config / application.rb as per the installation guide, an error will occur.
This can also be checked on the rails console.

```app/components/user_component.rb
class UserComponent < ActionView::Component::Base
  attr_reader :name

  def initialize(name:, style:)
    @name = name
  end
end
```

```
$ rails console
> UserComponent
=> NameError (uninitialized constant ActionView::Component)

> require "'action_view/component/railtie"
=> true

> UserComponent
=> NameError (uninitialized constant ActionView::Component)

> require "action_view/component"
=> true

> UserComponent
=> UserComponent
```

Therefore, I responded by changing the required path.
Guide has been modified accordingly.

## Environments

```
$ rails -v
Rails 6.0.2.1
$ ruby -v
ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-darwin17]
```