### PR TITLE
Allow Previews to have no layout 

### DIFF
--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -20,11 +20,14 @@ module ActionView
         end
 
         # Returns the html of the component in its layout
-        def call(example)
+        def call(example, layout: nil)
           example_html = new.public_send(example)
+          if layout.nil?
+            layout = @layout.nil? ? "layouts/application" : @layout
+          end
 
           Rails::ComponentExamplesController.render(template: "examples/show",
-                                                    layout: @layout || "layouts/application",
+                                                    layout: layout,
                                                     assigns: { example: example_html })
         end
 

--- a/test/action_view/preview_test.rb
+++ b/test/action_view/preview_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionView::PreviewTest < ActionView::Component::TestCase
+  def test_preview
+    assert_html_document(
+      PreviewComponentPreview.call(:default),
+      "Action View Component - Test",
+      <<~HTML
+        <div class="preview-component">
+        <h1>Lorem Ipsum</h1>
+
+        <button class="btn">Click me!</button>
+
+        </div>
+      HTML
+    )
+  end
+
+  def test_preview_with_layout
+    assert_html_document(
+      MyComponentPreview.call(:default),
+      "Action View Component - Admin - Test",
+      "<div>hello,world!</div>"
+    )
+  end
+
+  def test_preview_layout_override_with_false
+    assert_html_fragment(
+      MyComponentPreview.call(:default, layout: false),
+      "<div>hello,world!</div>"
+    )
+  end
+
+  def test_preview_with_no_layout
+    assert_html_fragment(
+      NoLayoutPreview.call(:default),
+      "<div>hello,world!</div>"
+    )
+  end
+
+  def test_preview_with_no_layout_override
+    assert_html_document(
+      NoLayoutPreview.call(:default, layout: "application"),
+      "Action View Component - Test",
+      "<div>hello,world!</div>"
+    )
+  end
+
+  private
+
+  def assert_html_document(preview_result, expected_title, expected_body)
+    result = Nokogiri::HTML(preview_result)
+    assert_html_matches expected_title, result.css('title').inner_html
+    assert_html_matches expected_body, result.css('body').inner_html
+  end
+
+  def assert_html_fragment(preview_result, expected_fragment)
+    result = Nokogiri::HTML.fragment(preview_result)
+    assert_html_matches expected_fragment, result.to_html
+  end
+
+end

--- a/test/action_view/preview_test.rb
+++ b/test/action_view/preview_test.rb
@@ -52,8 +52,8 @@ class ActionView::PreviewTest < ActionView::Component::TestCase
 
   def assert_html_document(preview_result, expected_title, expected_body)
     result = Nokogiri::HTML(preview_result)
-    assert_html_matches expected_title, result.css('title').inner_html
-    assert_html_matches expected_body, result.css('body').inner_html
+    assert_html_matches expected_title, result.css("title").inner_html
+    assert_html_matches expected_body, result.css("body").inner_html
   end
 
   def assert_html_fragment(preview_result, expected_fragment)

--- a/test/test/components/previews/no_layout_preview.rb
+++ b/test/test/components/previews/no_layout_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class NoLayoutPreview < ActionView::Component::Preview
+  layout false
+
+  def default
+    render(MyComponent)
+  end
+end


### PR DESCRIPTION
Fixes the bug that specifying `layout false` in a Preview was ignored because of a truthy check rather than a nil check. 

Also added the ability to override the layout in Preview.call. This allows for other integration options in particular setting the layout to false so we can build controllers that return just the component html without the layout chrome. For example a Rails backend for Storybook #159.