### PR TITLE
Support dynamic preview args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionview-component (1.6.1)
+    actionview-component (1.6.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -256,6 +256,41 @@ end
 The previews will be available in <http://localhost:3000/rails/components/test_component/with_default_title>
 and <http://localhost:3000/rails/components/test_component/with_long_title>.
 
+#### Previews with dynamic properties
+
+Previews can also be configured with properite to be passed to the Component from url parameters.
+
+The last example can be configured to make both `title` and `content` dynamic:
+
+```ruby
+# test/components/previews/test_component_preview.rb
+
+class TestComponentPreview < ActionView::Component::Preview
+  def with_default_title(title: "Test component default", content: "Hello, World!")
+    render(TestComponent, title: title) { content }
+  end
+  
+  ...
+end
+```
+
+The preview available at <http://localhost:3000/rails/components/test_component/with_default_title>
+would render the component html using the default values:
+
+```html
+<span title="Test component default">Hello, World!</span>
+```
+
+However, we can now override the `title` and `content` from the url. For example the url:
+<http://localhost:3000/rails/components/test_component/with_default_title?title=title%20override&content=Bye!> 
+will render the component html:
+
+```html
+<span title="title override">Bye!</span>
+```
+
+#### Preview Layouts
+
 Previews use the application layout by default, but you can also use other layouts from your app:
 
 ```ruby
@@ -267,6 +302,8 @@ class TestComponentPreview < ActionView::Component::Preview
   ...
 end
 ```
+
+#### Configuring preview classes location
 
 By default, the preview classes live in `test/components/previews`.
 This can be configured using the `preview_path` option.

--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -20,8 +20,9 @@ module ActionView
         end
 
         # Returns the html of the component in its layout
-        def call(example, layout: nil)
-          example_html = new.public_send(example)
+        def call(example, layout: nil, example_args: {})
+
+          example_html = example_html(example, example_args)
           if layout.nil?
             layout = @layout.nil? ? "layouts/application" : @layout
           end
@@ -80,6 +81,17 @@ module ActionView
 
         def show_previews
           Base.show_previews
+        end
+
+        def example_html(example, params)
+          example_method = new.public_method(example)
+
+          if example_method.arity == 0
+            example_method.call
+          else
+            method_args = example_method.parameters.map(&:last)
+            example_method.call(**params.slice(*method_args))
+          end
         end
       end
     end

--- a/lib/action_view/component/version.rb
+++ b/lib/action_view/component/version.rb
@@ -5,7 +5,7 @@ module ActionView
     module VERSION
       MAJOR = 1
       MINOR = 6
-      PATCH = 1
+      PATCH = 2
 
       STRING = [MAJOR, MINOR, PATCH].join(".")
     end

--- a/lib/railties/lib/rails/components_controller.rb
+++ b/lib/railties/lib/rails/components_controller.rb
@@ -20,11 +20,12 @@ class Rails::ComponentsController < Rails::ApplicationController # :nodoc:
   end
 
   def previews
-    if params[:path] == @preview.preview_name
+    if preview_params[:path] == @preview.preview_name
       @page_title = "Component Previews for #{@preview.preview_name}"
       render template: "components/previews"
     else
-      @example_name = File.basename(params[:path])
+      @example_name = File.basename(preview_params[:path])
+      @example_args = preview_params.except(:path, :controller, :action).to_h.symbolize_keys
       render template: "components/preview", layout: false
     end
   end
@@ -51,5 +52,9 @@ class Rails::ComponentsController < Rails::ApplicationController # :nodoc:
     I18n.with_locale(params[:locale] || I18n.default_locale) do
       yield
     end
+  end
+
+  def preview_params
+    @preview_params ||= params.permit!
   end
 end

--- a/lib/railties/lib/rails/templates/rails/components/preview.html.erb
+++ b/lib/railties/lib/rails/templates/rails/components/preview.html.erb
@@ -1,1 +1,1 @@
-<%= raw @preview.call(@example_name) %>
+<%= raw @preview.call(@example_name, example_args: @example_args) %>

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -145,6 +145,41 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Closed"
   end
 
+  test "renders preview with args uses defaults" do
+    get "/rails/components/erb_component/with_args"
+
+    assert_includes response.body, "Hello World!"
+    assert_includes response.body, "Bye!"
+  end
+
+  test "renders preview with args override" do
+    get "/rails/components/erb_component/with_args", params: {message: "See ya later!"}
+
+    assert_includes response.body, "Hello World!"
+    assert_includes response.body, "See ya later!"
+  end
+
+  test "renders preview with content override" do
+    get "/rails/components/erb_component/with_args", params: {message: "See ya later!", content: "Hey Buddy!"}
+
+    assert_includes response.body, "Hey Buddy!"
+    assert_includes response.body, "See ya later!"
+  end
+
+  test "renders preview with args extra params don't cause error" do
+    get "/rails/components/erb_component/with_args", params: { message: "See ya later!", foo: "bar"}
+
+    assert_includes response.body, "Hello World!"
+    assert_includes response.body, "See ya later!"
+  end
+
+  test "renders preview without args with params don't cause error" do
+    get "/rails/components/erb_component/default", params: { message: "See ya later!", foo: "bar"}
+
+    assert_includes response.body, "Hello World!"
+    assert_includes response.body, "Bye!"
+  end
+
   test "compiles unreferenced component" do
     assert UnreferencedComponent.compiled?
   end

--- a/test/action_view/preview_test.rb
+++ b/test/action_view/preview_test.rb
@@ -48,6 +48,70 @@ class ActionView::PreviewTest < ActionView::Component::TestCase
     )
   end
 
+  def test_preview_with_content
+    assert_html_document(
+      ErbComponentPreview.call(:default),
+      "Action View Component - Test",
+      <<~HTML
+        <div>
+          Hello World!
+          Bye!
+        </div>
+      HTML
+    )
+  end
+
+  def test_preview_with_args
+    assert_html_document(
+      ErbComponentPreview.call(:with_args),
+      "Action View Component - Test",
+      <<~HTML
+        <div>
+          Hello World!
+          Bye!
+        </div>
+      HTML
+    )
+  end
+
+  def test_preview_with_args_overrides
+    assert_html_document(
+      ErbComponentPreview.call(:with_args, example_args: {message: "See ya!"}),
+      "Action View Component - Test",
+      <<~HTML
+        <div>
+          Hello World!
+          See ya!
+        </div>
+      HTML
+    )
+  end
+
+  def test_preview_with_content_args_overrides
+    assert_html_document(
+      ErbComponentPreview.call(:with_args, example_args: {message: "See ya!", content: "Hi There!"}),
+      "Action View Component - Test",
+      <<~HTML
+        <div>
+          Hi There!
+          See ya!
+        </div>
+      HTML
+    )
+  end
+
+  def test_preview_with_content_and_layout_args_overrides
+    assert_html_fragment(
+      ErbComponentPreview.call(:with_args, layout: false, example_args: {message: "See ya!", content: "Hi There!"}),
+      <<~HTML
+        <div>
+          Hi There!
+          See ya!
+        </div>
+      HTML
+    )
+  end
+
   private
 
   def assert_html_document(preview_result, expected_title, expected_body)

--- a/test/test/components/previews/erb_component_preview.rb
+++ b/test/test/components/previews/erb_component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ErbComponentPreview < ActionView::Component::Preview
+  def default
+    render(ErbComponent, message: "Bye!") { "Hello World!" }
+  end
+
+  def with_args(message: "Bye!", content: "Hello World!")
+    render(ErbComponent, message: message) { content }
+  end
+end


### PR DESCRIPTION
Allow Previews to be configured with dynamic arguments.

Wire up the previews controller to allow those arguments to be passed via url parameters. 

The user experience here isn't great but it is functional. The big win of this change is that it sets us up to dynamically render Previews with other tools. In particular we can use the dynamic features as the backend for a Storybook and connect [Storybook Knobs](https://github.com/storybookjs/storybook/tree/master/addons/knobs) to the dynamic parameters.