### PR TITLE
Allow component initializers that take no arguments

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -132,6 +132,21 @@ module ActionView
           super
         end
 
+        def safe_new(options)
+          # Check the arity of `#initialize` to avoid passing an empty
+          # `options` hash when no arguments are expected. Also, check
+          # `options` to avoid dropping arguments passed to `#render`,
+          # which might hide a helpful `ArgumentError`.
+
+          arity = self.instance_method(:initialize).arity
+
+          if (options.blank? && arity.zero?)
+            self.new
+          else
+            self.new(options)
+          end
+        end
+
         def call_method_name(variant)
           if variant.present? && variants.include?(variant)
             "call_#{variant}"

--- a/lib/action_view/component/render_monkey_patch.rb
+++ b/lib/action_view/component/render_monkey_patch.rb
@@ -15,10 +15,12 @@ module ActionView
 
           options.render_in(self, &block)
         elsif options.is_a?(Class) && options < ActionView::Component::Base
-          options.new(args).render_in(self, &block)
+          options.safe_new(args).render_in(self, &block)
         elsif options.is_a?(Hash) && options.has_key?(:component)
-          options[:component].new(options[:locals]).render_in(self, &block)
+          options[:component].safe_new(options[:locals]).render_in(self, &block)
         elsif options.respond_to?(:to_component_class) && !options.to_component_class.nil?
+          # In this case, the `options` passed to `new` is the object on which `#to_component_class` is called. So we
+          # want the non-zero arity initializer to be called.
           options.to_component_class.new(options).render_in(self, &block)
         else
           super

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -17,6 +17,41 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "<div>hello,world!</div>", result.css("div").to_html
   end
 
+  def test_zero_arity_initializers
+      result = render_inline(ZeroArityComponent)
+
+      assert_html_matches "<div>hello,world!</div>", result.to_html
+  end
+
+  def test_zero_arity_initializers_with_hash_syntax
+    result = render_inline(component: ZeroArityComponent, locals: {})
+
+    assert_html_matches "<div>hello,world!</div>", result.to_html
+  end
+
+
+  def test_zero_arity_initializers_with_hash_syntax_and_no_locals
+    result = render_inline(component: ZeroArityComponent)
+
+    assert_html_matches "<div>hello,world!</div>", result.to_html
+  end
+
+  def test_zero_arity_initializer_with_to_component_class
+    exception = assert_raises ArgumentError do
+      render_inline(ZeroArity.new)
+    end
+
+    assert_includes exception.message, "wrong number of arguments (given 1, expected 0)"
+  end
+
+  def test_zero_arity_initializer_arguments_not_dropped
+    exception = assert_raises ArgumentError do
+      render_inline(ZeroArityComponent, unnecessary_attr: "Hello")
+    end
+
+    assert_includes exception.message, "wrong number of arguments (given 1, expected 0)"
+  end
+
   def test_checks_validations
     exception = assert_raises ActiveModel::ValidationError do
       render_inline(WrapperComponent)

--- a/test/app/components/zero_arity_component.html.erb
+++ b/test/app/components/zero_arity_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello,world!</div>

--- a/test/app/components/zero_arity_component.rb
+++ b/test/app/components/zero_arity_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ZeroArityComponent < ActionView::Component::Base
+  def initialize
+  end
+end

--- a/test/app/models/zero_arity.rb
+++ b/test/app/models/zero_arity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ZeroArity
+  # Used to test components that have initializers that take no arguments (arity == 0).
+
+  include ActiveModel::Model
+
+  attr_accessor :title
+end


### PR DESCRIPTION
### Motivation

@topherfangio Brought up something that I also found unexpected in [this comment](https://github.com/github/actionview-component/issues/15#issuecomment-531281205):

> 4. It seems like we are forced to pass arguments to a component? Example: I can't get render(MyComponent) to work. I keep getting the error wrong number of arguments (given 1, expected 0) when it calls my initializer. This just seems a bit strange.

While I'm not sure there's a lot of value to components that don't take any props, I do think this error message might be confusing, and could lead a developer that's newer to actionview-component to spend time trying to figure out if they're incorrectly calling `render`. And it's likely to come up for devs when starting a new component with TDD.

### Proposed change

What do people think of changing `Actionview::Base#render` to allow for 0-arity initializers? For example:

```
class ExampleComponent < ActionView::Component::Base
  def initialize
    # Takes no arguments.
  end
end
```

### Other changes considered

Initially, I wanted to avoid changing how render works, and instead change the error message to be more specific than ArgumentError. One way to do this would be to check the airity of the initializer when loading the component. And raise an error message like, "`Component #initialize must accept arguments`". 

However, when I tried to implement this it got a little tricky. I think the place to do the check is in ActionView::Component::Base (in a hook like `::inherited`). But since the component's initializer has not yet been loaded when code from `ActionView::Component::Base::inherited` is run, I'm not if that's possible. It seemed like we'd have to prepend a module and do some alias method chain style trickery with the component's `#initialize`, but that messed with the tactic of using the location of initialize's source location.

### Possible further work

I'm not sure, but I think we may also have to modify [ActionView::Helpers::RenderingHelper](https://github.com/joelhawksley/rails/blob/c221b5b448569771678279216360460e066095a7/actionview/lib/action_view/helpers/rendering_helper.rb#L38-L42) to mirror whatever changes we make here.