### PR TITLE
Fix Uninitialized Constant error #163

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/version_tmp/
 /tmp/
 /test/log/*
+/test/app/tmp/*
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -127,12 +127,6 @@ module ActionView
           instance_method(:initialize).source_location[0]
         end
 
-        def eager_load!
-          self.descendants.each do |descendant|
-            descendant.compile if descendant.has_initializer?
-          end
-        end
-
         def compiled?
           @compiled && ActionView::Base.cache_template_loading
         end

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails"
+require "action_view/component"
 
 module ActionView
   module Component
@@ -25,11 +26,18 @@ module ActionView
         require "railties/lib/rails/components_controller"
         require "railties/lib/rails/component_examples_controller"
 
-        app.config.eager_load_namespaces << ActionView::Component::Base
         options = app.config.action_view_component
 
         if options.show_previews && options.preview_path
           ActiveSupport::Dependencies.autoload_paths << options.preview_path
+        end
+      end
+
+      initializer "action_view_component.eager_load_actions" do
+        ActiveSupport.on_load(:after_initialize) do
+          ActionView::Component::Base.descendants.each do |descendant|
+            descendant.compile if descendant.has_initializer? && config.eager_load
+          end
         end
       end
 


### PR DESCRIPTION
This should fix the Uninitialized Constant error. 

Its standard practice to include the entire "gem" in a Railtie and we changed that with 1.6.0

See:
https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/railtie.rb#L4
https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/railtie.rb#L4