### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,30 @@
+<!-- **** Filing a Feature Request? Include these sections. **** -->
+
+### Feature request
+<!-- Provide a summary of the behavior. -->
+
+### Motivation
+
+<!-- What would you like to do with this feature? Can you provide
+context or references to similar behavior in other libraries. -->
+
+
+
+
+
+<!-- **** Filing a Bug Report? Include these sections. **** -->
+
+### Steps to reproduce
+<!-- Provide an series of steps or, better yet, a link to a repo to
+demonstrate the bug you've identified. -->
+
+### Expected behavior
+<!-- Tell us what should happen -->
+
+### Actual behavior
+<!-- Tell us what happens instead -->
+
+### System configuration
+**Rails version**:
+
+**Ruby version**:

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,19 @@
+<!-- https://github.com/github/actionview-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
+
+### Summary
+
+<!-- Provide a general description of the code changes in your pull
+request... were there any bugs you had fixed? If so, mention them. If
+these bugs have open GitHub issues, be sure to tag them here as well,
+to keep the conversation linked together. -->
+
+### Other Information
+
+<!-- If there's anything else that's important and relevant to your pull
+request, mention that information here. This could include
+benchmarks, or other information.
+
+If you are updating any of the CHANGELOG files or are asked to update the
+CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.
+
+Thanks for contributing to actionview-component! -->


### PR DESCRIPTION
### Summary

Add rudimentary issue and PR templates, adapted from the [templates in Rails](https://github.com/rails/rails/blob/master/.github/). This is probably overkill, but it would be nice to see something to start with when opening a new PR or issue.

### Other Information

Adding this will complete this checklist I see in the [community profile](https://github.com/github/actionview-component/community), which I feel compelled to complete 😆.

<img width="400" alt="Screen Shot 2020-01-05 at 11 57 13 AM" src="https://user-images.githubusercontent.com/896684/71785268-862cf980-2fb2-11ea-9add-914cc51d4efe.png">
