### PR TITLE
Remove initalizer requirement for Ruby 2.7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Pending
+
+* Remove initializer requirement for Ruby 2.7+
+
+    *Dylan Clark*
+
 # v1.8.1
 
 * Run validation checks before calling `#render?`.

--- a/README.md
+++ b/README.md
@@ -528,6 +528,11 @@ To use component previews, set the following in `config/application.rb`:
 config.action_view_component.preview_path = "#{Rails.root}/spec/components/previews"
 ```
 
+### Initializer requirement
+
+In Ruby 2.6.x and below, ActionView::Component requires the presence of an `initialize` method in each component. 
+However, `initialize` is no longer required for projects using 2.7.x and above.
+
 ## Frequently Asked Questions
 
 ### Can I use other templating languages besides ERB?

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -142,15 +142,11 @@ module ActionView
 
         def source_location
           @source_location ||=
-              begin
-                # Require #initialize to be defined so that we can use
-                # method#source_location to look up the file name
-                # of the component.
-                #
-                # If we were able to only support Ruby 2.7+,
-                # We could just use Module#const_source_location,
-                # rendering this unnecessary.
-                #
+              if const_source_location_supported?
+                const_source_location(self.name)[0]
+              else
+                # Require `#initialize` to be defined so that we can use `method#source_location`
+                # to look up the filename of the component.
                 initialize_method = instance_method(:initialize)
                 initialize_method.source_location[0] if initialize_method.owner == self
               end
@@ -210,6 +206,10 @@ module ActionView
 
         private
 
+        def const_source_location_supported?
+          respond_to? :const_source_location # introduced in Ruby 2.7
+        end
+
         def matching_views_in_source_location
           return [] unless source_location
           (Dir["#{source_location.chomp(File.extname(source_location))}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location])
@@ -232,7 +232,12 @@ module ActionView
           @template_errors ||=
             begin
               errors = []
-              errors << "#{self} must implement #initialize." if source_location.nil?
+              if source_location.nil? && !const_source_location_supported?
+                # Require `#initialize` to be defined so that we can use `method#source_location`
+                # to look up the filename of the component.
+                errors << "#{self} must implement #initialize."
+              end
+
               errors << "Could not find a template file for #{self}." if templates.empty?
 
               if templates.count { |template| template[:variant].nil? } > 1

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -372,6 +372,12 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "<span>The Awesome post component!</span>", render_inline(post).to_html
   end
 
+  def test_missing_initializer
+    skip unless const_source_location_supported?
+
+    assert_html_matches "Hello, world!", render_inline(MissingInitializerComponent).text
+  end
+
   private
 
   def modify_file(file, content)

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -186,6 +186,14 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "does not compile components without initializers" do
+    skip if const_source_location_supported?
+
     assert !MissingInitializerComponent.compiled?
+  end
+
+  test "compiles components without initializers" do
+    skip unless const_source_location_supported?
+
+    assert MissingInitializerComponent.compiled?
   end
 end

--- a/test/action_view/invalid_components_test.rb
+++ b/test/action_view/invalid_components_test.rb
@@ -2,6 +2,8 @@
 
 class ActionView::InvalidComponentTest < ActionView::Component::TestCase
   def test_raises_error_when_initializer_is_not_defined
+    skip if const_source_location_supported?
+
     exception = assert_raises ActionView::Component::TemplateError do
       render_inline(MissingInitializerComponent)
     end

--- a/test/app/components/missing_initializer_component.html.erb
+++ b/test/app/components/missing_initializer_component.html.erb
@@ -1,0 +1,1 @@
+<div>Hello, world!</div>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,3 +31,7 @@ end
 def assert_html_matches(expected, actual)
   assert_equal(trim_result(expected), trim_result(actual))
 end
+
+def const_source_location_supported?
+  Module.respond_to? :const_source_location
+end


### PR DESCRIPTION
### Motivation

As discussed in github#93, Ruby 2.7 introduces [`#const_source_location`](https://ruby-doc.org/core-2.7.0/Module.html#method-i-const_source_location) to find the location of constants. This means that we no longer have to find the location of components through the location of their `#initialize` method, and we can remove the initializer requirement for Ruby 2.7+.

### Changes

* Use `#const_source_location` in `ActionView::Component::Base::source_location`, when it's available. 
* Move the initializer-less component test out of invalid, and in to a proper component test. Test it still throws the error for Rubies < 2.7.
* Change eager-loading logic for Ruby 2.7+

### Todo

- [x] Update CI to test Ruby 2.7 once supported by `actions` (actions/setup-ruby#45, actions/virtual-environments#209).
- [x] Rebase to pick up workflow changes in #200 when that's merged.

(The old todo, `Test eager loading change`, is no longer necessary.)