### PR TITLE
Remove the unneeded ComponentExamplesController and simplify preview rendering

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -199,7 +199,7 @@ module ActionView
 
         def matching_views_in_source_location
           return [] unless source_location
-          (Dir["#{source_location.sub(/#{File.extname(source_location)}$/, '')}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location])
+          (Dir["#{source_location.chomp(File.extname(source_location))}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location])
         end
 
         def templates

--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -26,9 +26,7 @@ module ActionView
             layout = @layout.nil? ? "layouts/application" : @layout
           end
 
-          Rails::ComponentExamplesController.render(template: "examples/show",
-                                                    layout: layout,
-                                                    assigns: { example: example_html })
+          ApplicationController.render(inline: "<%= raw('#{example_html}') %>", layout: layout)
         end
 
         # Returns the component object class associated to the preview.

--- a/lib/action_view/component/preview.rb
+++ b/lib/action_view/component/preview.rb
@@ -6,10 +6,9 @@ module ActionView
   module Component # :nodoc:
     class Preview
       extend ActiveSupport::DescendantsTracker
-      include ActionView::Component::TestHelpers
 
-      def render(component, *locals, &block)
-        render_inline(component, *locals, &block)
+      def render(component, **args, &block)
+        { component: component, args: args, block: block }
       end
 
       class << self
@@ -19,19 +18,14 @@ module ActionView
           descendants
         end
 
-        # Returns the html of the component in its layout
-        def call(example, layout: nil)
-          example_html = new.public_send(example)
-          if layout.nil?
-            layout = @layout.nil? ? "layouts/application" : @layout
-          end
-
-          ApplicationController.render(inline: "<%= raw('#{example_html}') %>", layout: layout)
+        # Returns the arguments for rendering of the component in its layout
+        def render_args(example)
+          new.public_send(example).merge(layout: @layout)
         end
 
         # Returns the component object class associated to the preview.
         def component
-          self.name.sub(%r{Preview$}, "").constantize
+          name.chomp("Preview").constantize
         end
 
         # Returns all of the available examples for the component preview.
@@ -56,7 +50,7 @@ module ActionView
 
         # Returns the underscored name of the component preview without the suffix.
         def preview_name
-          name.sub(/Preview$/, "").underscore
+          name.chomp("Preview").underscore
         end
 
         # Setter for layout name.

--- a/lib/action_view/component/railtie.rb
+++ b/lib/action_view/component/railtie.rb
@@ -24,7 +24,6 @@ module ActionView
 
       initializer "action_view_component.set_autoload_paths" do |app|
         require "railties/lib/rails/components_controller"
-        require "railties/lib/rails/component_examples_controller"
 
         options = app.config.action_view_component
 

--- a/lib/railties/lib/rails.rb
+++ b/lib/railties/lib/rails.rb
@@ -2,5 +2,4 @@
 
 module Rails
   autoload :ComponentsController
-  autoload :ComponentExamplesController
 end

--- a/lib/railties/lib/rails/component_examples_controller.rb
+++ b/lib/railties/lib/rails/component_examples_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails/application_controller"
-load "config/application.rb" unless Rails.root
-
-class Rails::ComponentExamplesController < ActionController::Base # :nodoc:
-  prepend_view_path File.expand_path("templates/rails", __dir__)
-  append_view_path Rails.root.join("app/views")
-end

--- a/lib/railties/lib/rails/components_controller.rb
+++ b/lib/railties/lib/rails/components_controller.rb
@@ -4,6 +4,7 @@ require "rails/application_controller"
 
 class Rails::ComponentsController < Rails::ApplicationController # :nodoc:
   prepend_view_path File.expand_path("templates/rails", __dir__)
+  prepend_view_path "#{Rails.root}/app/views/" if defined?(Rails.root)
 
   around_action :set_locale, only: :previews
   before_action :find_preview, only: :previews
@@ -25,7 +26,10 @@ class Rails::ComponentsController < Rails::ApplicationController # :nodoc:
       render template: "components/previews"
     else
       @example_name = File.basename(params[:path])
-      render template: "components/preview", layout: false
+      @render_args = @preview.render_args(@example_name)
+      layout = @render_args[:layout]
+      opts = layout.nil? ? {} : { layout: layout }
+      render template: "components/preview", **opts
     end
   end
 

--- a/lib/railties/lib/rails/templates/rails/components/preview.html.erb
+++ b/lib/railties/lib/rails/templates/rails/components/preview.html.erb
@@ -1,1 +1,1 @@
-<%= raw @preview.call(@example_name) %>
+<%= render(@render_args[:component], **@render_args[:args], &@render_args[:block])%>

--- a/lib/railties/lib/rails/templates/rails/examples/show.html.erb
+++ b/lib/railties/lib/rails/templates/rails/examples/show.html.erb
@@ -1,1 +1,0 @@
-<%= raw @example %>

--- a/test/action_view/preview_test.rb
+++ b/test/action_view/preview_test.rb
@@ -2,10 +2,12 @@
 
 require "test_helper"
 
-class ActionView::PreviewTest < ActionView::Component::TestCase
+class ActionView::PreviewTest < ActionDispatch::IntegrationTest
   def test_preview
+    get "/rails/components/preview_component/default"
+
     assert_html_document(
-      PreviewComponentPreview.call(:default),
+      response.body,
       "Action View Component - Test",
       <<~HTML
         <div class="preview-component">
@@ -19,31 +21,20 @@ class ActionView::PreviewTest < ActionView::Component::TestCase
   end
 
   def test_preview_with_layout
+    get "/rails/components/my_component/default"
+
     assert_html_document(
-      MyComponentPreview.call(:default),
+      response.body,
       "Action View Component - Admin - Test",
       "<div>hello,world!</div>"
     )
   end
 
-  def test_preview_layout_override_with_false
-    assert_html_fragment(
-      MyComponentPreview.call(:default, layout: false),
-      "<div>hello,world!</div>"
-    )
-  end
-
   def test_preview_with_no_layout
-    assert_html_fragment(
-      NoLayoutPreview.call(:default),
-      "<div>hello,world!</div>"
-    )
-  end
+    get "/rails/components/no_layout/default"
 
-  def test_preview_with_no_layout_override
-    assert_html_document(
-      NoLayoutPreview.call(:default, layout: "application"),
-      "Action View Component - Test",
+    assert_html_fragment(
+      response.body,
       "<div>hello,world!</div>"
     )
   end


### PR DESCRIPTION
### Summary

Remove ComponentExamplesController in favor of inline the ComponentsController itself doing the rendering.

One less moving part for this gem to contain AND we don't have to include the TestHelpers in Preview






