### PR TITLE
Render component by condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ class PopupComponent < ActionView::Component::Base
     @current_user = current_user
   end
 
-  # show popup only for signed users
+  # show popup for signed users only
   def show_popup?
     current_user.present?
   end

--- a/README.md
+++ b/README.md
@@ -367,6 +367,28 @@ end
 <% end %>
 ```
 
+### Render by condition
+
+Method `render_if` could be defined at the class level. When resolved to `false` the component wouldn't be rendered:
+
+`app/components/popup_component.rb`:
+```ruby
+class PopupComponent < ActionView::Component::Base
+  render_if { show_popup? }
+
+  attr_reader :current_user
+
+  def initialize(current_user: nil)
+    @current_user = current_user
+  end
+
+  # show popup only for signed users
+  def show_popup?
+    current_user.present?
+  end
+end
+```
+
 ### Testing
 
 Components are unit tested directly. The `render_inline` test helper wraps the result in `Nokogiri.HTML`, allowing us to test the component above as:

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -48,7 +48,7 @@ module ActionView
         @virtual_path ||= virtual_path
         @variant = @lookup_context.variants.first
 
-        return '' unless should_render?
+        return "" unless should_render?
 
         old_current_template = @current_template
         @current_template = self

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -17,6 +17,12 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "<div>hello,world!</div>", result.css("div").to_html
   end
 
+  def test_skip_render
+    result = render_component(SkippedComponent)
+
+    assert_html_matches "", result.to_html
+  end
+
   def test_checks_validations
     exception = assert_raises ActiveModel::ValidationError do
       render_inline(WrapperComponent)
@@ -344,6 +350,13 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
 
   def test_renders_component_with_rb_in_its_name
     assert_html_matches "Editorb!\n", render_inline(EditorbComponent).text
+  end
+
+  def test_to_component_class
+    post = Post.new(title: "Awesome post")
+
+    assert_html_matches PostComponent, post.to_component_class
+    assert_html_matches "<span>The Awesome post component!</span>", render_inline(post).to_html
   end
 
   def test_to_component_class

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -359,13 +359,6 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "<span>The Awesome post component!</span>", render_inline(post).to_html
   end
 
-  def test_to_component_class
-    post = Post.new(title: "Awesome post")
-
-    assert_html_matches PostComponent, post.to_component_class
-    assert_html_matches "<span>The Awesome post component!</span>", render_inline(post).to_html
-  end
-
   private
 
   def modify_file(file, content)

--- a/test/app/components/skipped_component.html.erb
+++ b/test/app/components/skipped_component.html.erb
@@ -1,0 +1,1 @@
+Don`t render this

--- a/test/app/components/skipped_component.rb
+++ b/test/app/components/skipped_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SkippedComponent < ActionView::Component::Base
+  render_if { false }
+
+  def initialize(*); end
+end


### PR DESCRIPTION
### Summary

This PR adds ability to skip render component if required conditions not meeted. Currently we use the following monkey patch:

```ruby
class PopupComponent < ActionView::Component::Base
  attr_reader :current_user

  def initialize(current_user: nil)
    @current_user = current_user
  end

  def render_in(view_context, *)
     @view_context = view_context
     return '' unless show_popup?
  end

  # show popup for signed users only
  def show_popup?
    current_user.present?
  end
end
```
