### PR TITLE
Add `#render?` hook to easily allow components to be no-ops

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -40,6 +40,8 @@ module ActionView
       # <span title="greeting">Hello, world!</span>
       #
       def render_in(view_context, *args, &block)
+        return '' unless render?
+
         self.class.compile!
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer
@@ -57,6 +59,10 @@ module ActionView
         send(self.class.call_method_name(@variant))
       ensure
         @current_template = old_current_template
+      end
+
+      def render?
+        true
       end
 
       def initialize(*); end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -40,7 +40,7 @@ module ActionView
       # <span title="greeting">Hello, world!</span>
       #
       def render_in(view_context, *args, &block)
-        return '' unless render?
+        return "" unless render?
 
         self.class.compile!
         @view_context = view_context

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -346,6 +346,14 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "Editorb!\n", render_inline(EditorbComponent).text
   end
 
+  def test_conditional_rendering
+    assert_includes render_inline(ConditionalRenderComponent, should_render: true).to_html,
+                    "<div>component was rendered</div>"
+
+    assert_equal render_inline(ConditionalRenderComponent, should_render: false).to_html,
+                    ""
+  end
+
   def test_to_component_class
     post = Post.new(title: "Awesome post")
 

--- a/test/app/components/conditional_render_component.html.erb
+++ b/test/app/components/conditional_render_component.html.erb
@@ -1,0 +1,1 @@
+<div>component was rendered</div>

--- a/test/app/components/conditional_render_component.rb
+++ b/test/app/components/conditional_render_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ConditionalRenderComponent < ActionView::Component::Base
+  def initialize(should_render:)
+    @should_render = should_render
+  end
+
+  def render?
+    @should_render
+  end
+end


### PR DESCRIPTION
<!-- https://github.com/github/actionview-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

This pull request introduces a new method, `#render?`, which indicates if the component should render at all (defaults to `true`).

What problem does this solve?

Our application has a handful of components that should only be displayed in certain scenarios. Some examples are banners that appear at the top of the page:

- "Your free trial ends in {x} days"
- "Your account is past due"
- "Please confirm your email address"

In order to show/hide these components, we had to either include logic in the view:

```erb
<!-- app/views/_alerts.html.erb -->
<% if subscription.past_due? %>
  <%= render(PastDueAlertComponent, subscription: subscription) %>
<% end %>
```

or in the component itself:

```erb
<!-- app/components/past_due_alert_component.html.erb -->
<% if subscription.past_due? %>
  <p>Your account is past due.</p>
<% end %>
```

This isn't _terrible_, but our team began to dislike having this high-level logic live inside views. It would be much cleaner to have this kind of "render, or don't" logic in Ruby. We accomplished this by adding a `render?` method to our `ApplicationComponent`:

```ruby
# app/components/application_component.rb
class ApplicationComponent < ActionView::Component::Base
  def render_in(*args)
    render? ? super(*args) : ''
  end

  def render?
    true
  end
end
```

which allows components to easily decide if they should render at all: 

```ruby
# app/components/past_due_alert_component.rb
class PastDueAlertComponent < ApplicationComponent
  def initialize(subscription:)
    @subscription = subscription
  end

  def render?
    subscription.past_due?
  end
end
```

This makes the views easier to follow (less logic & nesting), reduces the amount of data that must leak into the view (this change allowed us to remove several `attr_readers`):

```erb
<!-- app/views/_alerts.html.erb -->
<%= render(PastDueAlertComponent, subscription: subscription) %>
```

or in the component itself:

```erb
<!-- app/components/past_due_alert_component.html.erb -->
<p>Your account is past due.</p>
```

After trying this approach, the Ruby class feels like a really great place to encapsulate the logic that determines whether or not a component should render at all, given it's internal state / business logic.