### PR TITLE
Separate context initialization and render itself

### DIFF
--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -17,6 +17,7 @@ module ActionView
     autoload :TestCase
     autoload :RenderMonkeyPatch
     autoload :TemplateError
+    autoload :MissingInitializerError
   end
 end
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -40,15 +40,20 @@ module ActionView
       # <span title="greeting">Hello, world!</span>
       #
       def render_in(view_context, *args, &block)
-        return "" unless render?
-
-        self.class.compile!
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer
         @lookup_context ||= view_context.lookup_context
         @view_flow ||= view_context.view_flow
         @virtual_path ||= virtual_path
         @variant = @lookup_context.variants.first
+
+        compile_and_render(&block)
+      end
+
+      def compile_and_render(&block)
+        return "" unless render?
+        
+        self.class.compile!
         old_current_template = @current_template
         @current_template = self
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -56,7 +56,7 @@ module ActionView
 
       def compile_and_render(&block)
         return "" unless render?
-        
+
         self.class.compile!
         old_current_template = @current_template
         @current_template = self

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -40,6 +40,10 @@ module ActionView
       # <span title="greeting">Hello, world!</span>
       #
       def render_in(view_context, *args, &block)
+        if self.class.source_location.nil?
+          raise ActionView::Component::MissingInitializerError.new("#{self.class} must implement #initialize.")
+        end
+
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer
         @lookup_context ||= view_context.lookup_context
@@ -230,7 +234,6 @@ module ActionView
           @template_errors ||=
             begin
               errors = []
-              errors << "#{self} must implement #initialize." if source_location.nil?
               errors << "Could not find a template file for #{self}." if templates.empty?
 
               if templates.count { |template| template[:variant].nil? } > 1

--- a/lib/action_view/component/missing_initializer_error.rb
+++ b/lib/action_view/component/missing_initializer_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Component
+    class MissingInitializerError < StandardError; end
+  end
+end

--- a/test/action_view/invalid_components_test.rb
+++ b/test/action_view/invalid_components_test.rb
@@ -2,7 +2,7 @@
 
 class ActionView::InvalidComponentTest < ActionView::Component::TestCase
   def test_raises_error_when_initializer_is_not_defined
-    exception = assert_raises ActionView::Component::TemplateError do
+    exception = assert_raises ActionView::Component::MissingInitializerError do
       render_inline(MissingInitializerComponent)
     end
 


### PR DESCRIPTION
### Summary

This PR separates context initalization from render itself. 

My use cases of this:
1) can override `compile_and_render` to add cache
```ruby
def compile_and_render
  Rails.cache.fetch([cache_key_base, user_type, :footer], expires_in: 30.minutes) do
    super
  end
end
```
Caching at controller side decreases logic complexity of template part. Also it allows do less work to show component when cached, it should affects performance

2) can override `compile_and_render` to add inherited components
```ruby
class PriceComponent < ActionView::Component::Base
  def compile_and_render
    if user_type == 'retail'
      render(Product::RetailPriceComponent)
    else
      render(Product::PartnerPriceComponent)
    end
  end
end
```

Also please note moving `render?` check to `compile_and_render`. It allows to add some additional checks to overrided `render?` method:
```ruby
def render?
  view_context.cookies[:show] == false
end
```

And finally i had to separate `MissingInitializerError`. Several reasons here: 
- `virtual_path` requires initializer check to be done
But also:
- Missing initializer is not "template" error by meaning
- Should raise this error as soon as possible, that's why i move it to beginning of `render_in`
