### PR TITLE
Separated render method

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,21 @@ end
 <%= render(ConfirmEmailComponent, user: current_user) %>
 ```
 
+### Override Render
+
+Components can override a `#render_template` method which renders compiled template. For example, you can wrap rendering with controller-level caching:
+
+```ruby
+# app/components/overrided_render_component.rb
+class OverridedRenderComponent < ActionView::Component::Base
+  def render_template
+    Rails.cache.fetch("cached-component") do
+      super
+    end
+  end
+end
+```
+
 ### Testing
 
 Components are unit tested directly. The `render_inline` test helper wraps the result in `Nokogiri.HTML`, allowing us to test the component above as:

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -48,6 +48,10 @@ module ActionView
         @virtual_path ||= virtual_path
         @variant = @lookup_context.variants.first
 
+        @content = view_context.capture(self, &block) if block_given?
+
+        validate!
+
         return "" unless render?
 
         render_template(&block)
@@ -72,12 +76,6 @@ module ActionView
       def render_template(&block)
         old_current_template = @current_template
         @current_template = self
-
-        @content = view_context.capture(self, &block) if block_given?
-
-        validate!
-
-        return "" unless render?
 
         send(self.class.call_method_name(@variant))
       ensure

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -48,6 +48,28 @@ module ActionView
         @virtual_path ||= virtual_path
         @variant = @lookup_context.variants.first
 
+        return "" unless render?
+
+        render_template(&block)
+      end
+
+      # Method which actual do render. Called by #render_in
+      # For example, it can be used to cache component
+      #
+      # block: optional block to be captured within the view context
+      #
+      # Example subclass:
+      #
+      # app/components/my_component.rb:
+      # class MyComponent < ActionView::Component::Base
+      #   def render_template(&block)
+      #     Rails.cache.fetch(cache_key) do
+      #       super
+      #     end
+      #   end
+      # end
+      #
+      def render_template(&block)
         old_current_template = @current_template
         @current_template = self
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -365,6 +365,15 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_empty render_inline(RenderCheckComponent).text, ""
   end
 
+  def test_override_render_template
+    Rails.cache.clear
+
+    assert_includes render_inline(OverridedRenderComponent, version: 1).to_html, "Cache 1"
+    assert_includes render_inline(OverridedRenderComponent, version: 2).to_html, "Cache 1"
+
+    Rails.cache.clear
+  end
+
   def test_to_component_class
     post = Post.new(title: "Awesome post")
 

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -145,6 +145,20 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_empty response.body.strip
   end
 
+  test "override render_template" do
+    Rails.cache.clear
+
+    get "/overrided_render?version=1"
+    assert_response :success
+    assert_html_matches "Cache 1", response.body
+
+    get "/overrided_render?version=2"
+    assert_response :success
+    assert_html_matches "Cache 1", response.body
+
+    Rails.cache.clear
+  end
+
   test "renders component preview" do
     get "/rails/components/my_component/default"
 

--- a/test/app/components/overrided_render_component.html.erb
+++ b/test/app/components/overrided_render_component.html.erb
@@ -1,0 +1,1 @@
+Cache <%= version %>

--- a/test/app/components/overrided_render_component.rb
+++ b/test/app/components/overrided_render_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class OverridedRenderComponent < ActionView::Component::Base
+  attr_reader :version
+  private :version
+
+  def initialize(version:)
+    @version = version
+  end
+
+  def render_template
+    Rails.cache.fetch("cached-component") do
+      super
+    end
+  end
+end

--- a/test/app/views/integration_examples/overrided_render.html.erb
+++ b/test/app/views/integration_examples/overrided_render.html.erb
@@ -1,0 +1,1 @@
+<%= render(OverridedRenderComponent, version: params[:version]) %>

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -10,4 +10,5 @@ Dummy::Application.routes.draw do
   get :variants, to: "integration_examples#variants"
   get :cached, to: "integration_examples#cached"
   get :render_check, to: "integration_examples#render_check"
+  get :overrided_render, to: "integration_examples#overrided_render"
 end


### PR DESCRIPTION
### Summary

This PR separates context initalization from render itself. 

Use cases:
1) can override `render_template` to add cache
```ruby
def render_template
  Rails.cache.fetch([cache_key_base, user_type, :footer], expires_in: 30.minutes) do
    super
  end
end
```
```