### PR TITLE
Fix generator placing namespaced components in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tmp/
 /test/log/*
 /test/app/tmp/*
+/test/tmp/*
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,7 @@ inherit_gem:
   rubocop-github:
     - config/default.yml
     - config/rails.yml
+
+AllCops:
+  Exclude:
+    - "test/tmp/**/*"

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -10,11 +10,11 @@ module Rails
       check_class_collision suffix: "Component"
 
       def create_component_file
-        template "component.rb", File.join("app/components",  "#{file_name}_component.rb")
+        template "component.rb", File.join("app/components", class_path, "#{file_name}_component.rb")
       end
 
       def create_template_file
-        template "component.html.erb", File.join("app/components",  "#{file_name}_component.html.erb")
+        template "component.html.erb", File.join("app/components", class_path, "#{file_name}_component.html.erb")
       end
 
       private

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -6,7 +6,7 @@ module Rspec
       source_root File.expand_path("templates", __dir__)
 
       def create_test_file
-        template "component_spec.rb", File.join("spec/components", "#{file_name}_component_spec.rb")
+        template "component_spec.rb", File.join("spec/components", class_path, "#{file_name}_component_spec.rb")
       end
 
       private

--- a/lib/rails/generators/test_unit/component_generator.rb
+++ b/lib/rails/generators/test_unit/component_generator.rb
@@ -7,7 +7,7 @@ module TestUnit
       check_class_collision suffix: "ComponentTest"
 
       def create_test_file
-        template "component_test.rb", File.join("test/components", "#{file_name}_component_test.rb")
+        template "component_test.rb", File.join("test/components", class_path, "#{file_name}_component_test.rb")
       end
 
       private

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "rails/generators/test_case"
+require "rails/generators/component/component_generator"
+
+Rails.application.load_generators
+
+class ComponentGeneratorTest < Rails::Generators::TestCase
+  tests Rails::Generators::ComponentGenerator
+  destination File.expand_path("../tmp", __dir__)
+  setup :prepare_destination
+
+  arguments %w[user]
+
+  def test_component_with_required_content
+    Thor::LineEditor.stub :readline, "Y" do
+      run_generator
+    end
+
+    assert_file "app/components/user_component.rb" do |component|
+      assert_match(/class UserComponent < /, component)
+      assert_match(/validates :content, presence: true/, component)
+    end
+
+    assert_file "app/components/user_component.html.erb" do |view|
+      assert_match(/<%= content %>/, view)
+    end
+  end
+
+  def test_component_without_required_content
+    Thor::LineEditor.stub :readline, "n" do
+      run_generator
+    end
+
+    assert_file "app/components/user_component.rb" do |component|
+      assert_match(/class UserComponent < /, component)
+      refute_match(/validates :content, presence: true/, component)
+    end
+
+    assert_file "app/components/user_component.html.erb" do |view|
+      assert_match(/<div>Add User template here<\/div>/, view)
+    end
+  end
+
+  def test_component_with_namespace
+    Thor::LineEditor.stub :readline, "n" do
+      run_generator %w[admins/user]
+    end
+
+    assert_file "app/components/admins/user_component.rb", /class Admins::UserComponent < /
+    assert_file "app/components/admins/user_component.html.erb"
+  end
+end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "rails/generators/test_case"
 require "rails/generators/component/component_generator"


### PR DESCRIPTION
### Summary

When generating namespaced components, the generated class names are correct, but the generated files are placed in the root `app/components` directory, and not in the namespace subdirectory.

This means running `rails g component admins/user` will correctly generate `Admins::UserComponent`, but the generated files look like this:
* generated: `app/components/user_component.rb`
should be: `app/components/admins/user_component.rb`
* generated: `app/components/user_component.html.erb` 
should be: `app/components/admins/user_component.html.erb`
* generated: `test/components/user_component_test.rb`
should be: `app/components/admins/user_component_test.rb`

This PR fixes that by adding the `class_path` to the generated file path and adds a test for the generator.

### Other Information

If/when this gets merged I've got another PR ready that separates the template generation into a separate `erb` generator specifically and adds a generator for `slim` (which I use in my projects).