### PR TITLE
Validate components before checking for conditional rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Run validation checks before calling `#render?`.
+
+    *Ash Wilson*
+
 # v1.8.0
 
 * Remove the unneeded ComponentExamplesController and simplify preview rendering.

--- a/README.md
+++ b/README.md
@@ -583,10 +583,10 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |@elia|@cesariouy|@spdawson|@rmacklin|@michaelem|
 |Milan||United Kingdom||Berlin|
 
-|<img src="https://avatars.githubusercontent.com/mellowfish?s=256" alt="mellowfish" width="128" />|<img src="https://avatars.githubusercontent.com/horacio?s=256" alt="horacio" width="128" />|<img src="https://avatars.githubusercontent.com/dukex?s=256" alt="dukex" width="128" />|<img src="https://avatars.githubusercontent.com/dark-panda?s=256" alt="dark-panda" width="128" />|
-|:---:|:---:|:---:|:---:|
-|@mellowfish|@horacio|@dukex|@dark-panda|
-|Spring Hill, TN|Buenos Aires|São Paulo||
+|<img src="https://avatars.githubusercontent.com/mellowfish?s=256" alt="mellowfish" width="128" />|<img src="https://avatars.githubusercontent.com/horacio?s=256" alt="horacio" width="128" />|<img src="https://avatars.githubusercontent.com/dukex?s=256" alt="dukex" width="128" />|<img src="https://avatars.githubusercontent.com/dark-panda?s=256" alt="dark-panda" width="128" />|<img src="https://avatars.githubusercontent.com/smashwilson?s=256" alt="smashwilson" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|@mellowfish|@horacio|@dukex|@dark-panda|@smashwilson|
+|Spring Hill, TN|Buenos Aires|São Paulo||Gambrills, MD|
 
 ## License
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -48,14 +48,14 @@ module ActionView
         @virtual_path ||= virtual_path
         @variant = @lookup_context.variants.first
 
-        return "" unless render?
-
         old_current_template = @current_template
         @current_template = self
 
         @content = view_context.capture(self, &block) if block_given?
 
         validate!
+
+        return "" unless render?
 
         send(self.class.call_method_name(@variant))
       ensure

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -352,6 +352,11 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
 
     assert_equal render_inline(ConditionalRenderComponent, should_render: false).to_html,
                     ""
+
+    exception = assert_raises ActiveModel::ValidationError do
+      render_inline(ConditionalRenderComponent, should_render: nil)
+    end
+    assert_equal exception.message, "Validation failed: Should render is not included in the list"
   end
 
   def test_render_check

--- a/test/app/components/conditional_render_component.rb
+++ b/test/app/components/conditional_render_component.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 class ConditionalRenderComponent < ActionView::Component::Base
+  validates :should_render, inclusion: { in: [true, false] }
+
   def initialize(should_render:)
     @should_render = should_render
   end
 
+  attr_reader :should_render
+
   def render?
-    @should_render
+    unless [true, false].include?(should_render)
+      raise RuntimeError.new("should_render wasn't validated!")
+    end
+
+    should_render
   end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/actionview-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

It's useful to be able to rely on component input validation within a `render?` method, so that you can use input variables to derive your rendering decision. This changes the order of rendering to perform validation _first_, then check `render?` just before performing the actual render.
