### PR TITLE
Update workflow config to include Ruby 2.7

### DIFF
--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.0.0, 5.2.3, 6.0.0, master]
-        ruby_version: [2.4.x, 2.5.x, 2.6.x]
+        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
         exclude:
           - rails_version: master
             ruby_version: 2.4.x
@@ -22,7 +22,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Build and test with Rake
       run: |
-        gem install bundler:1.14.0
+        gem install bundler:1.17.3
         bundle update
         bundle install --jobs 4 --retry 3
         bundle exec rake


### PR DESCRIPTION
<!-- See https://github.com/github/actionview-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

PR #174 introduces a feature that requires Ruby 2.7. In order to test this feature, need to run CI against 2.7.  

Let's update our workflow configuration accordingly.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->

Note that the version of bundler used in the workflow was updated to match our Gemfile.lock. It was pinned to 1.14 in #35, but seems to be OK to update (and the old version was causing issues with 2.7).