### PR TITLE
Optional validation

### DIFF
--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -17,6 +17,7 @@ module ActionView
     autoload :TestCase
     autoload :RenderMonkeyPatch
     autoload :TemplateError
+    autoload :NoOpValidations
   end
 end
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -5,7 +5,6 @@ require "active_support/configurable"
 module ActionView
   module Component
     class Base < ActionView::Base
-      include ActiveModel::Validations
       include ActiveSupport::Configurable
       include ActionView::Component::Previewable
 
@@ -13,6 +12,10 @@ module ActionView
 
       class_attribute :content_areas, default: []
       self.content_areas = [] # default doesn't work until Rails 5.2
+
+      # `validation_module` should be set to a string if present
+      class_attribute :validation_module, default: "ActiveModel::Validations"
+      self.validation_module = "ActiveModel::Validations" # default doesn't work until Rails 5.2
 
       # Entrypoint for rendering components. Called by ActionView::Base#render.
       #
@@ -128,6 +131,7 @@ module ActionView
       class << self
         def inherited(child)
           child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
+          child.include self.validation_module ? self.validation_module.safe_constantize : ActionView::Component::NoOpValidations
 
           super
         end

--- a/lib/action_view/component/no_op_validations.rb
+++ b/lib/action_view/component/no_op_validations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ActionView
+  module Component # :nodoc:
+    module NoOpValidations
+      extend ActiveSupport::Concern
+
+      included do
+        def validate!
+        end
+      end
+    end
+  end
+end

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -365,6 +365,13 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_empty render_inline(RenderCheckComponent).text, ""
   end
 
+  def test_custom_validation
+    exception = assert_raises RuntimeError do
+      render_inline(CustomValidationComponent)
+    end
+    assert_equal exception.message, "validate! was called"
+  end
+
   def test_to_component_class
     post = Post.new(title: "Awesome post")
 

--- a/test/app/components/custom_validation_component.html.erb
+++ b/test/app/components/custom_validation_component.html.erb
@@ -1,0 +1,1 @@
+Rendered

--- a/test/app/components/custom_validation_component.rb
+++ b/test/app/components/custom_validation_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CustomValidations
+  def validate!
+    raise RuntimeError.new("validate! was called")
+  end
+end
+
+ActionView::Component::Base.validation_module = "CustomValidations"
+
+class CustomValidationComponent < ActionView::Component::Base
+  def initialize(*); end
+end
+
+ActionView::Component::Base.validation_module = ActiveModel::Validations.name


### PR DESCRIPTION
### Summary

This PR remove hardcoded inclusion of `ActiveModel::Validations` and allow to add it optionally. 

Component with validation [15 times slower](https://github.com/github/actionview-component/pull/192#issuecomment-580746645). I suppose it usable for 1 of 100 cases. Validation is too sloow to run it for every component