### PR TITLE
Add deprecation warning for public methods on components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Pending
+* Deprecate allowing public methods on components.
+
+    *Joel Hawksley*
 
 * Remove initializer requirement for Ruby 2.7+
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ class MyComponentTest < ActionView::Component::TestCase
 end
 ```
 
-In general, we’ve found it makes the most sense to test components based on their rendered HTML.
+In general, we’ve found it makes the most sense to test components based on their rendered HTML. A warning will be raised if any public methods are defined on a component.
 
 #### Action Pack Variants
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -9,6 +9,8 @@ module ActionView
       include ActiveSupport::Configurable
       include ActionView::Component::Previewable
 
+      ALLOWED_PUBLIC_INSTANCE_METHODS = [:default_url_options?, :default_url_options, :default_url_options=].freeze
+
       delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
       class_attribute :content_areas, default: []
@@ -169,6 +171,12 @@ module ActionView
           if template_errors.present?
             raise ActionView::Component::TemplateError.new(template_errors) if validate
             return false
+          end
+
+          (self.instance_methods(false) - ALLOWED_PUBLIC_INSTANCE_METHODS).each do |disallowed_public_instance_method|
+            ActiveSupport::Deprecation.warn(
+              "Only #initialize can be public: #{disallowed_public_instance_method} must be private. This warning will become an exception in v2.0.0"
+            )
           end
 
           templates.each do |template|

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -378,6 +378,10 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "Hello, world!", render_inline(MissingInitializerComponent).text
   end
 
+  def test_component_with_public_method
+    assert_includes render_inline(PublicMethodComponent).text, "Public method component"
+  end
+
   private
 
   def modify_file(file, content)

--- a/test/app/components/public_method_component.html.erb
+++ b/test/app/components/public_method_component.html.erb
@@ -1,0 +1,1 @@
+Public method component

--- a/test/app/components/public_method_component.rb
+++ b/test/app/components/public_method_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PublicMethodComponent < ActionView::Component::Base
+  def initialize(*); end
+
+  def public_method; end
+end


### PR DESCRIPTION
In practice, we've yet to find a legitimate reason to allow
public methods to be defined on components. Furthermore,
allowing them enables them to be tested in place of the HTML
output of the component, which we consider to be an anti-
pattern in our experience with the library so far. This
has been a common trap for developers new to components
to fall into, so I feel it makes sense to have the library
enforce this rule.

This deprecation warning will change to an exception
in release v2.0.0.
