### PR TITLE
relax capybara dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Relax Capybara requirement.
+
+    *Joel Hawksley*
+
 # v1.11.0
 
 * Add support for Capybara matchers.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     actionview-component (1.11.0)
-      capybara (>= 3.26)
+      capybara (>= 3)
 
 GEM
   remote: https://rubygems.org/

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency     "capybara", ">= 3.26"
+  spec.add_runtime_dependency     "capybara", ">= 3"
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "= 5.1.0"


### PR DESCRIPTION
We depend on an older version of Capybara. Hopefully
this change will allow us to proceed without
having to update our dependencies.