### PR TITLE
Render in args

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -14,7 +14,7 @@ module ActionView
       class_attribute :content_areas, default: []
       self.content_areas = [] # default doesn't work until Rails 5.2
 
-      # Entrypoint for rendering components. Called by ActionView::Base#render.
+      # Entrypoint for rendering components.
       #
       # view_context: ActionView context from calling view
       # args(hash): params to be passed to component being rendered
@@ -35,7 +35,7 @@ module ActionView
       # <span title="<%= @title %>">Hello, <%= content %>!</span>
       #
       # In use:
-      # <%= render MyComponent, title: "greeting" do %>world<% end %>
+      # <%= render MyComponent.new(title: "greeting") do %>world<% end %>
       # returns:
       # <span title="greeting">Hello, world!</span>
       #

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -17,7 +17,6 @@ module ActionView
       # Entrypoint for rendering components.
       #
       # view_context: ActionView context from calling view
-      # args(hash): params to be passed to component being rendered
       # block: optional block to be captured within the view context
       #
       # returns HTML that has been escaped by the respective template handler
@@ -39,7 +38,7 @@ module ActionView
       # returns:
       # <span title="greeting">Hello, world!</span>
       #
-      def render_in(view_context, *args, &block)
+      def render_in(view_context, &block)
         self.class.compile!
         @view_context = view_context
         @view_renderer ||= view_context.view_renderer


### PR DESCRIPTION
`render_in` has no use for `*args`. Let's remove it.

