### PR TITLE
Add gem version to ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -23,3 +23,5 @@ context or references to similar behavior in other libraries? -->
 **Rails version**:
 
 **Ruby version**:
+
+**Gem version**:


### PR DESCRIPTION
### Summary

I just open issue about ruby 2.7 and realize that issue template miss gem version. So, adding.