### PR TITLE
Before render

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -54,9 +54,11 @@ module ActionView
 
         before_render_check
 
-        return "" unless render?
-
-        send(self.class.call_method_name(@variant))
+        if render?
+          send(self.class.call_method_name(@variant))
+        else
+          ""
+        end
       ensure
         @current_template = old_current_template
       end

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -52,13 +52,17 @@ module ActionView
 
         @content = view_context.capture(self, &block) if block_given?
 
-        validate!
+        before_render_check
 
         return "" unless render?
 
         send(self.class.call_method_name(@variant))
       ensure
         @current_template = old_current_template
+      end
+
+      def before_render_check
+        validate!
       end
 
       def render?

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -355,6 +355,12 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_selector("div")
   end
 
+  def test_no_validations_component
+    render_inline(NoValidationsComponent.new)
+
+    assert_selector("div")
+  end
+
   private
 
   def modify_file(file, content)

--- a/test/app/components/no_validations_component.html.erb
+++ b/test/app/components/no_validations_component.html.erb
@@ -1,0 +1,1 @@
+<div><%= content %></div>

--- a/test/app/components/no_validations_component.rb
+++ b/test/app/components/no_validations_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NoValidationsComponent < ActionView::Component::Base
+  validates :content, presence: true
+
+  def initialize(*); end
+
+  def before_render_check
+    #noop
+  end
+end


### PR DESCRIPTION
After speaking with @rainerborene, @jonspalmer, and several folks here at work, we think it's best to move forward with removing validations from the library in `v2`.

In this PR, we'll start this process by moving the call to `validate!` to a before_render_check method, which can be subclassed to be a no-op.

After this, we will introduce the new `ViewComponent::Base` class, we will remove the `validate!` call and the inclusion of `ActiveModel::Validations`.