### PR TITLE
revert: Remove initializer requirement for Ruby 2.7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # master
 
+* Revert: Remove initializer requirement for Ruby 2.7+
+
+    *Joel Hawksley*
+
 * Restructure Railtie into Engine
-    
+
     *Sean Doyle*
 
 # v1.11.1

--- a/README.md
+++ b/README.md
@@ -508,8 +508,7 @@ config.action_view_component.preview_path = "#{Rails.root}/spec/components/previ
 
 ### Initializer requirement
 
-In Ruby 2.6.x and below, ActionView::Component requires the presence of an `initialize` method in each component. 
-However, `initialize` is no longer required for projects using 2.7.x and above.
+ActionView::Component requires the presence of an `initialize` method in each component.
 
 ## Frequently Asked Questions
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -147,14 +147,12 @@ module ActionView
 
         def source_location
           @source_location ||=
-              if const_source_location_supported?
-                const_source_location(self.name)[0]
-              else
-                # Require `#initialize` to be defined so that we can use `method#source_location`
-                # to look up the filename of the component.
-                initialize_method = instance_method(:initialize)
-                initialize_method.source_location[0] if initialize_method.owner == self
-              end
+            begin
+              # Require `#initialize` to be defined so that we can use `method#source_location`
+              # to look up the filename of the component.
+              initialize_method = instance_method(:initialize)
+              initialize_method.source_location[0] if initialize_method.owner == self
+            end
         end
 
         def compiled?
@@ -211,10 +209,6 @@ module ActionView
 
         private
 
-        def const_source_location_supported?
-          respond_to? :const_source_location # introduced in Ruby 2.7
-        end
-
         def matching_views_in_source_location
           return [] unless source_location
           (Dir["#{source_location.chomp(File.extname(source_location))}.*{#{ActionView::Template.template_handler_extensions.join(',')}}"] - [source_location])
@@ -237,7 +231,7 @@ module ActionView
           @template_errors ||=
             begin
               errors = []
-              if source_location.nil? && !const_source_location_supported?
+              if source_location.nil?
                 # Require `#initialize` to be defined so that we can use `method#source_location`
                 # to look up the filename of the component.
                 errors << "#{self} must implement #initialize."

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -341,14 +341,6 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_selector("span", text: "The Awesome post component!")
   end
 
-  def test_missing_initializer
-    skip unless const_source_location_supported?
-
-    render_inline(MissingInitializerComponent.new)
-
-    assert_text("Hello, world!")
-  end
-
   def test_assert_select
     render_inline(MyComponent.new)
 

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -145,14 +145,6 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "does not compile components without initializers" do
-    skip if const_source_location_supported?
-
     assert !MissingInitializerComponent.compiled?
-  end
-
-  test "compiles components without initializers" do
-    skip unless const_source_location_supported?
-
-    assert MissingInitializerComponent.compiled?
   end
 end

--- a/test/action_view/invalid_components_test.rb
+++ b/test/action_view/invalid_components_test.rb
@@ -2,8 +2,6 @@
 
 class ActionView::InvalidComponentTest < ActionView::Component::TestCase
   def test_raises_error_when_initializer_is_not_defined
-    skip if const_source_location_supported?
-
     exception = assert_raises ActionView::Component::TemplateError do
       render_inline(MissingInitializerComponent)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,3 @@ def trim_result(content)
 
   doc.to_s.strip
 end
-
-def const_source_location_supported?
-  Module.respond_to? :const_source_location
-end


### PR DESCRIPTION
[Fixes: #221]

