### PR TITLE
Set template filepath and line number for better backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Improve backtraces from exceptions raised in templates
+
+    *Blake Williams*
+
 # v1.12.0
 
 * Revert: Remove initializer requirement for Ruby 2.7+

--- a/README.md
+++ b/README.md
@@ -570,6 +570,11 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |@mellowfish|@horacio|@dukex|@dark-panda|@smashwilson|
 |Spring Hill, TN|Buenos Aires|São Paulo||Gambrills, MD|
 
+|<img src="https://avatars.githubusercontent.com/blakewilliams?s=256" alt="blakewilliams" width="128" />|
+|:---:|
+|@blakewilliams|
+|Boston, MA|
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -175,7 +175,7 @@ module ActionView
           end
 
           templates.each do |template|
-            class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            class_eval <<-RUBY, template[:path], -1
               def #{call_method_name(template[:variant])}
                 @output_buffer = ActionView::OutputBuffer.new
                 #{compiled_template(template[:path])}

--- a/test/action_view/invalid_components_test.rb
+++ b/test/action_view/invalid_components_test.rb
@@ -32,4 +32,12 @@ class ActionView::InvalidComponentTest < ActionView::Component::TestCase
 
     assert_includes error.message, "More than one template found for variants 'test' and 'testing' in TooManySidecarFilesForVariantComponent"
   end
+
+  def test_backtrace_returns_correct_file_and_line_number
+    error = assert_raises NameError do
+      render_inline(ExceptionInTemplateComponent)
+    end
+
+    assert_match %r[app/components/exception_in_template_component\.html\.erb:2], error.backtrace[0]
+  end
 end

--- a/test/app/components/exception_in_template_component.html.erb
+++ b/test/app/components/exception_in_template_component.html.erb
@@ -1,0 +1,3 @@
+<p>
+  <%= a_method_that_does_not_exist_i_hope %>
+</p>

--- a/test/app/components/exception_in_template_component.rb
+++ b/test/app/components/exception_in_template_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ExceptionInTemplateComponent < ActionView::Component::Base
+  def initialize(*)
+  end
+end


### PR DESCRIPTION
Currently `__FILE__` and `__LINE__` are the arguments passed to
`class_eval` which means when an exception is raised in the template it
will point back to the component instead of the correct line of the
template.

This updates the filepath and line number arguments passed to
`class_eval` to point to the template instead of the component.

resolves https://github.com/github/actionview-component/issues/85

Here's some screenshots displaying the difference:

Before:

<img width="581" alt="Screen Shot 2020-02-26 at 5 31 11 PM" src="https://user-images.githubusercontent.com/342554/75394675-a6947880-58be-11ea-92a2-6b3f15ad3152.png">

After:

<img width="556" alt="Screen Shot 2020-02-26 at 5 30 52 PM" src="https://user-images.githubusercontent.com/342554/75394679-a98f6900-58be-11ea-9bba-1fd331d23f20.png">
