### PR TITLE
add rudimentary support for rendering components from controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # master
 
-* Improve backtraces from exceptions raised in templates
+* Allow components to be rendered inside controllers.
+
+    *Joel Hawksley*
+
+* Improve backtraces from exceptions raised in templates.
 
     *Blake Williams*
 

--- a/lib/action_view/component.rb
+++ b/lib/action_view/component.rb
@@ -16,6 +16,7 @@ module ActionView
     autoload :TestHelpers
     autoload :TestCase
     autoload :RenderMonkeyPatch
+    autoload :RenderingMonkeyPatch
     autoload :TemplateError
   end
 end

--- a/lib/action_view/component/engine.rb
+++ b/lib/action_view/component/engine.rb
@@ -46,6 +46,10 @@ module ActionView
         ActiveSupport.on_load(:action_view) do
           ActionView::Base.prepend ActionView::Component::RenderMonkeyPatch
         end
+
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::Base.prepend ActionView::Component::RenderingMonkeyPatch
+        end
       end
 
       config.after_initialize do |app|

--- a/lib/action_view/component/rendering_monkey_patch.rb
+++ b/lib/action_view/component/rendering_monkey_patch.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Component
+    module RenderingMonkeyPatch # :nodoc:
+      def render(options = {}, args = {}, &block)
+        if options.respond_to?(:render_in)
+          self.response_body = options.render_in(self.view_context, &block)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/action_view/component/rendering_monkey_patch.rb
+++ b/lib/action_view/component/rendering_monkey_patch.rb
@@ -3,9 +3,9 @@
 module ActionView
   module Component
     module RenderingMonkeyPatch # :nodoc:
-      def render(options = {}, args = {}, &block)
+      def render(options = {}, args = {})
         if options.respond_to?(:render_in)
-          self.response_body = options.render_in(self.view_context, &block)
+          self.response_body = options.render_in(self.view_context)
         else
           super
         end

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -10,6 +10,23 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select("div", "Foo\n  bar")
   end
 
+  test "rendering component in a controller" do
+    get "/controller_inline_baseline"
+
+    assert_select("div", "bar")
+    assert_response :success
+
+    baseline_response = response.body
+
+    get "/controller_inline"
+    assert_select("div", "bar")
+    assert_response :success
+
+    inline_response = response.body
+
+    assert_equal baseline_response, inline_response
+  end
+
   test "rendering component with content" do
     get "/content"
     assert_response :success

--- a/test/app/components/controller_inline_component.html.erb
+++ b/test/app/components/controller_inline_component.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "integration_examples/controller_inline", locals: { message: @message } %>

--- a/test/app/components/controller_inline_component.rb
+++ b/test/app/components/controller_inline_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ControllerInlineComponent < ActionView::Component::Base
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/test/app/controllers/integration_examples_controller.rb
+++ b/test/app/controllers/integration_examples_controller.rb
@@ -6,4 +6,12 @@ class IntegrationExamplesController < ActionController::Base
   def variants
     request.variant = params[:variant].to_sym if params[:variant]
   end
+
+  def controller_inline
+    render(ControllerInlineComponent.new(message: "bar"))
+  end
+
+  def controller_inline_baseline
+    render("integration_examples/_controller_inline", locals: { message: "bar" })
+  end
 end

--- a/test/app/views/integration_examples/_controller_inline.html.erb
+++ b/test/app/views/integration_examples/_controller_inline.html.erb
@@ -1,0 +1,1 @@
+<div><%= message %></div>

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -9,4 +9,6 @@ Dummy::Application.routes.draw do
   get :variants, to: "integration_examples#variants"
   get :cached, to: "integration_examples#cached"
   get :render_check, to: "integration_examples#render_check"
+  get :controller_inline, to: "integration_examples#controller_inline"
+  get :controller_inline_baseline, to: "integration_examples#controller_inline_baseline"
 end


### PR DESCRIPTION
This change introduces the ability to render components from
controllers, mimicking the behavior introduced in
https://github.com/rails/rails/pull/37919.

[Fixes: #38]

